### PR TITLE
feat(adapters): add Gemini CLI adapter

### DIFF
--- a/.ai-review.yaml
+++ b/.ai-review.yaml
@@ -6,7 +6,7 @@ version: "1.0"
 global:
   max_rounds: 4
   language: "en"
-  default_cli: "claude"     # "claude" or "codex"
+  default_cli: "claude"     # "claude", "codex", or "gemini"
   timeout_ms: 120000        # 2 minutes
 
 lenses:

--- a/src/__tests__/adapters.test.ts
+++ b/src/__tests__/adapters.test.ts
@@ -1,22 +1,55 @@
 import { describe, it, expect } from "vitest";
+import {
+  stripCodeFences,
+  extractJsonFromText,
+} from "../adapters/parse-utils.js";
 
-// Test parseOutput / extractContent for ClaudeCodeAdapter and CodexAdapter.
-// Since these are private methods, we test equivalent logic directly
-// rather than going through the adapter. Focus is on output parsing.
+// Test parseOutput / extractContent for each adapter.
+// Since parseOutput is private, we test equivalent logic directly.
+// Shared utilities (stripCodeFences, extractJsonFromText) are imported
+// from parse-utils; adapter-specific envelope handling is replicated here.
+
+describe("parse-utils", () => {
+  describe("stripCodeFences", () => {
+    it("removes ```json and closing ``` fences", () => {
+      const input = '```json\n{"key": "value"}\n```';
+      expect(stripCodeFences(input)).toBe('{"key": "value"}');
+    });
+
+    it("returns plain text unchanged", () => {
+      expect(stripCodeFences('{"key": "value"}')).toBe('{"key": "value"}');
+    });
+  });
+
+  describe("extractJsonFromText", () => {
+    it("extracts JSON with findings from mixed text", () => {
+      const json = JSON.stringify({
+        findings: [{ file: "a.ts", severity: "warning" }],
+        overall_assessment: "minor_issues",
+      });
+      const text = `Some preamble\n${json}`;
+      const result = extractJsonFromText(text);
+      expect(result?.findings).toHaveLength(1);
+    });
+
+    it("returns null when no findings JSON present", () => {
+      expect(extractJsonFromText("no json here")).toBeNull();
+    });
+
+    it("returns null for malformed JSON with findings keyword", () => {
+      expect(extractJsonFromText('{"findings": broken}')).toBeNull();
+    });
+  });
+});
 
 describe("ClaudeCodeAdapter parseOutput (indirect)", () => {
-  // Directly test parseOutput logic (using equivalent logic since the method is private)
   function parseClaudeOutput(stdout: string) {
     try {
       const envelope = JSON.parse(stdout);
       const content = envelope.result ?? envelope;
 
       if (typeof content === "string") {
-        const cleaned = content
-          .replace(/^```json\s*/m, "")
-          .replace(/\s*```$/m, "")
-          .trim();
-        return JSON.parse(cleaned);
+        return JSON.parse(stripCodeFences(content));
       }
 
       if (content.findings) {
@@ -27,18 +60,6 @@ describe("ClaudeCodeAdapter parseOutput (indirect)", () => {
     } catch {
       return extractJsonFromText(stdout);
     }
-  }
-
-  function extractJsonFromText(text: string) {
-    const jsonMatch = text.match(/\{[\s\S]*"findings"[\s\S]*\}/);
-    if (jsonMatch) {
-      try {
-        return JSON.parse(jsonMatch[0]);
-      } catch {
-        return null;
-      }
-    }
-    return null;
   }
 
   it("parses JSON envelope with result string", () => {
@@ -112,11 +133,7 @@ describe("CodexAdapter parseOutput / extractContent (indirect)", () => {
           const event = JSON.parse(line);
           const content = extractContent(event);
           if (content && content.includes('"findings"')) {
-            const cleaned = content
-              .replace(/^```json\s*/m, "")
-              .replace(/\s*```$/m, "")
-              .trim();
-            return JSON.parse(cleaned);
+            return JSON.parse(stripCodeFences(content));
           }
         } catch {
           continue;
@@ -204,5 +221,107 @@ describe("CodexAdapter parseOutput / extractContent (indirect)", () => {
     it("returns null for unrecognized events", () => {
       expect(extractContent({ type: "tool_call" })).toBeNull();
     });
+  });
+});
+
+// Mirrors GeminiAdapter's private envelope handling for isolated unit testing.
+// Shared parse utilities are imported from parse-utils.
+describe("GeminiAdapter parseOutput (indirect)", () => {
+  const TEST_SESSION_ID = "test-uuid";
+
+  function parseGeminiOutput(stdout: string) {
+    try {
+      const envelope = JSON.parse(stdout);
+
+      if (envelope.error) {
+        return null;
+      }
+
+      const content = envelope.response;
+      if (typeof content !== "string") {
+        return null;
+      }
+
+      try {
+        return JSON.parse(stripCodeFences(content));
+      } catch {
+        return extractJsonFromText(content);
+      }
+    } catch {
+      return extractJsonFromText(stdout);
+    }
+  }
+
+  it("parses standard envelope with response string", () => {
+    const findings = {
+      findings: [{ file: "a.ts", severity: "warning" }],
+      overall_assessment: "minor_issues",
+    };
+    const input = JSON.stringify({
+      session_id: TEST_SESSION_ID,
+      response: JSON.stringify(findings),
+      stats: { total_tokens: 100 },
+    });
+    const result = parseGeminiOutput(input);
+    expect(result.findings).toHaveLength(1);
+    expect(result.overall_assessment).toBe("minor_issues");
+  });
+
+  it("parses response wrapped in code fence", () => {
+    const inner = JSON.stringify({
+      findings: [{ file: "b.ts", severity: "blocker" }],
+      overall_assessment: "significant_issues",
+    });
+    const input = JSON.stringify({
+      session_id: TEST_SESSION_ID,
+      response: "```json\n" + inner + "\n```",
+    });
+    const result = parseGeminiOutput(input);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe("blocker");
+  });
+
+  it("returns null for error envelope", () => {
+    const input = JSON.stringify({
+      error: { type: "Error", message: "model not found" },
+    });
+    expect(parseGeminiOutput(input)).toBeNull();
+  });
+
+  it("extracts response ignoring stats field", () => {
+    const findings = {
+      findings: [],
+      overall_assessment: "clean",
+    };
+    const input = JSON.stringify({
+      session_id: TEST_SESSION_ID,
+      response: JSON.stringify(findings),
+      stats: {
+        total_tokens: 500,
+        input_tokens: 400,
+        output_tokens: 100,
+      },
+    });
+    const result = parseGeminiOutput(input);
+    expect(result.findings).toHaveLength(0);
+    expect(result.overall_assessment).toBe("clean");
+  });
+
+  it("returns null for empty output", () => {
+    expect(parseGeminiOutput("")).toBeNull();
+  });
+
+  it("returns null for invalid JSON output", () => {
+    expect(parseGeminiOutput("not json at all")).toBeNull();
+  });
+
+  it("falls back to extractJsonFromText for mixed text output", () => {
+    const findings = JSON.stringify({
+      findings: [{ file: "c.ts", severity: "nitpick" }],
+      overall_assessment: "minor_issues",
+    });
+    const text = `Here is the review:\n${findings}`;
+    const result = parseGeminiOutput(text);
+    expect(result.findings).toHaveLength(1);
   });
 });

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -8,6 +8,7 @@ import type {
   LensOutput,
   ToolPolicy,
 } from "./types.js";
+import { stripCodeFences, extractJsonFromText } from "./parse-utils.js";
 
 const execAsync = promisify(execFile);
 
@@ -113,11 +114,7 @@ export class ClaudeCodeAdapter implements CLIAdapter {
       const content = envelope.result ?? envelope;
 
       if (typeof content === "string") {
-        const cleaned = content
-          .replace(/^```json\s*/m, "")
-          .replace(/\s*```$/m, "")
-          .trim();
-        return JSON.parse(cleaned);
+        return JSON.parse(stripCodeFences(content));
       }
 
       if (content.findings) {
@@ -126,20 +123,7 @@ export class ClaudeCodeAdapter implements CLIAdapter {
 
       return null;
     } catch {
-      return this.extractJsonFromText(stdout);
+      return extractJsonFromText(stdout);
     }
-  }
-
-  /** Fallback for when JSON output has surrounding text: extract object with findings key */
-  private extractJsonFromText(text: string): LensOutput | null {
-    const jsonMatch = text.match(/\{[\s\S]*?"findings"[\s\S]*?\}(?=\s*$)/);
-    if (jsonMatch) {
-      try {
-        return JSON.parse(jsonMatch[0]);
-      } catch {
-        return null;
-      }
-    }
-    return null;
   }
 }

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -9,6 +9,7 @@ import type {
   ToolPolicy,
 } from "./types.js";
 import { MAX_BUFFER_BYTES, WRITE_CAPABLE_TOOLS } from "./types.js";
+import { stripCodeFences } from "./parse-utils.js";
 
 const execAsync = promisify(execFile);
 
@@ -123,11 +124,7 @@ export class CodexAdapter implements CLIAdapter {
           const event = JSON.parse(line);
           const content = this.extractContent(event);
           if (content && content.includes('"findings"')) {
-            const cleaned = content
-              .replace(/^```json\s*/m, "")
-              .replace(/\s*```$/m, "")
-              .trim();
-            return JSON.parse(cleaned);
+            return JSON.parse(stripCodeFences(content));
           }
         } catch {
           continue;

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,0 +1,136 @@
+import { spawn, execFile } from "child_process";
+import { promisify } from "util";
+import type {
+  CLIAdapter,
+  CLIRequest,
+  CLIResponse,
+  LensOutput,
+  ToolPolicy,
+} from "./types.js";
+import { WRITE_CAPABLE_TOOLS } from "./types.js";
+import { stripCodeFences, extractJsonFromText } from "./parse-utils.js";
+
+const execAsync = promisify(execFile);
+
+export class GeminiAdapter implements CLIAdapter {
+  readonly name = "gemini";
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execAsync("gemini", ["--version"]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async execute(request: CLIRequest): Promise<CLIResponse> {
+    const args = this.buildArgs(request);
+    const start = Date.now();
+
+    return new Promise((resolve) => {
+      const child = spawn("gemini", args, {
+        cwd: request.cwd,
+        env: {
+          ...process.env,
+          GEMINI_SYSTEM_MD: request.systemPromptPath,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout.on("data", (data) => {
+        stdout += data.toString();
+      });
+      child.stderr.on("data", (data) => {
+        stderr += data.toString();
+      });
+
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+      }, request.timeoutMs);
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        resolve({
+          parsed: this.parseOutput(stdout),
+          rawStdout: stdout,
+          rawStderr: stderr,
+          exitCode: typeof code === "number" ? code : 1,
+          durationMs: Date.now() - start,
+        });
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        resolve({
+          parsed: null,
+          rawStdout: stdout,
+          rawStderr: err.message,
+          exitCode: 1,
+          durationMs: Date.now() - start,
+        });
+      });
+
+      // Send prompt via stdin (-p "" makes gemini read from stdin)
+      child.stdin.write(request.userPrompt);
+      child.stdin.end();
+    });
+  }
+
+  private buildArgs(request: CLIRequest): string[] {
+    const args: string[] = [
+      "-p",
+      "",
+      "-o",
+      "json",
+      "-m",
+      request.model,
+      ...this.mapToolPolicy(request.toolPolicy),
+    ];
+
+    return args;
+  }
+
+  private mapToolPolicy(policy: ToolPolicy): string[] {
+    switch (policy.type) {
+      case "none":
+        return ["--approval-mode", "plan"];
+      case "read_only":
+        return ["--approval-mode", "plan"];
+      case "explicit": {
+        const hasWriteTools = policy.tools.some((t) =>
+          WRITE_CAPABLE_TOOLS.some((w) => t === w || t.startsWith(`${w}(`))
+        );
+        // Gemini has no --allowedTools equivalent; use plan for read-only, yolo for write
+        return hasWriteTools ? ["--yolo"] : ["--approval-mode", "plan"];
+      }
+    }
+  }
+
+  private parseOutput(stdout: string): LensOutput | null {
+    try {
+      // gemini -o json -> { session_id, response, stats }
+      const envelope = JSON.parse(stdout);
+
+      if (envelope.error) {
+        return null;
+      }
+
+      const content = envelope.response;
+      if (typeof content !== "string") {
+        return null;
+      }
+
+      try {
+        return JSON.parse(stripCodeFences(content));
+      } catch {
+        return extractJsonFromText(content);
+      }
+    } catch {
+      return extractJsonFromText(stdout);
+    }
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,12 +1,14 @@
 import type { CLIAdapter } from "./types.js";
 import { ClaudeCodeAdapter } from "./claude-code.js";
 import { CodexAdapter } from "./codex.js";
+import { GeminiAdapter } from "./gemini.js";
 
-export type CLIName = "claude" | "codex";
+export type CLIName = "claude" | "codex" | "gemini";
 
 const adapterFactories: Record<CLIName, () => CLIAdapter> = {
   claude: () => new ClaudeCodeAdapter(),
   codex: () => new CodexAdapter(),
+  gemini: () => new GeminiAdapter(),
 };
 
 /** Get adapter. Checks availability before returning. */
@@ -36,6 +38,8 @@ function getInstallHint(name: CLIName): string {
       return "npm install -g @anthropic-ai/claude-code";
     case "codex":
       return "npm install -g @openai/codex";
+    case "gemini":
+      return "npm install -g @google/gemini-cli";
   }
 }
 

--- a/src/adapters/parse-utils.ts
+++ b/src/adapters/parse-utils.ts
@@ -1,0 +1,22 @@
+import type { LensOutput } from "./types.js";
+
+/** Remove markdown ```json ... ``` code fences from a string */
+export function stripCodeFences(text: string): string {
+  return text
+    .replace(/^```json\s*/m, "")
+    .replace(/\s*```$/m, "")
+    .trim();
+}
+
+/** Fallback: extract a JSON object containing a "findings" key from mixed text */
+export function extractJsonFromText(text: string): LensOutput | null {
+  const jsonMatch = text.match(/\{[\s\S]*"findings"[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      return JSON.parse(jsonMatch[0]);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extract shared parse utilities (`stripCodeFences`, `extractJsonFromText`) into `src/adapters/parse-utils.ts` to eliminate duplication across 3 adapters
- Add `GeminiAdapter` as the third CLI backend (`cli: "gemini"` in `.ai-review.yaml`)
- System prompt via `GEMINI_SYSTEM_MD` env var, structured output via `-o json`, tool policy mapped to `--approval-mode plan` / `--yolo`
- 26 tests passing (5 new for parse-utils, 7 for Gemini output parsing)

## Test plan
- [x] `npx vitest run src/__tests__/adapters.test.ts` — 26 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx eslint src/adapters/gemini.ts` — no lint errors
- [x] diffelens self-review: 3 rounds, all 6 findings resolved, approved
- [ ] Manual: set `cli: "gemini"` on a lens and run `npx tsx src/main.ts --diff-target branch` with `GEMINI_API_KEY`