### PR TITLE
feat: add --base/--head CLI options for commit hash targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ npx tsx src/main.ts
 
 When GITHUB_TOKEN is not set, the summary is printed to stdout.
 
+## Local Mode
+
+```bash
+# Review staged + unstaged changes (default)
+npx tsx src/main.ts
+
+# Review current branch diff against main
+npx tsx src/main.ts --diff-target branch
+
+# Review up to a specific commit
+npx tsx src/main.ts --head abc1234
+
+# Review a specific commit range
+npx tsx src/main.ts --base def5678 --head abc1234
+
+# Review from a specific base to current HEAD
+npx tsx src/main.ts --base def5678
+```
+
+### CLI Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--diff-target` | `staged` / `unstaged` / `all` / `branch` / `commits` | `all` |
+| `--base <ref>` | Base git ref for diff range | merge-base with main |
+| `--head <ref>` | Head git ref for diff range | current HEAD |
+| `--config <path>` | Config file path | `.ai-review.yaml` |
+| `--state-dir <path>` | State directory | `.ai-review-state` |
+| `--mode` | `github` / `local` | auto-detect |
+
+> When `--base` or `--head` is provided, `--diff-target` is ignored.
+
 ## Configuration
 
 Place `.ai-review.yaml` at the repository root. Each lens can be configured with its own CLI, model, and tool permissions.

--- a/src/__tests__/diff.test.ts
+++ b/src/__tests__/diff.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateGitRef } from "../options.js";
+import type { RunOptions } from "../options.js";
+
+// Mock child_process to control detectDefaultBranch behavior
+vi.mock("child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("child_process")>();
+  return {
+    ...original,
+    execSync: vi.fn().mockImplementation((command: string, options?: object) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/main\n";
+      }
+      return original.execSync(command, options);
+    }),
+  };
+});
+
+import { buildDiffCommand, buildRefDiffCommand, detectDefaultBranch } from "../diff.js";
+import { execSync } from "child_process";
+
+const mockedExecSync = vi.mocked(execSync);
+
+// ============================================================
+// validateGitRef
+// ============================================================
+
+describe("validateGitRef", () => {
+  it("accepts valid refs", () => {
+    expect(validateGitRef("abc123")).toBe(true);
+    expect(validateGitRef("main")).toBe(true);
+    expect(validateGitRef("feature/foo")).toBe(true);
+    expect(validateGitRef("HEAD~3")).toBe(true);
+    expect(validateGitRef("v1.0.0")).toBe(true);
+    expect(validateGitRef("abc123def456abc123def456abc123def456abcd")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateGitRef("")).toBe(false);
+  });
+
+  it("rejects shell metacharacters", () => {
+    expect(validateGitRef("foo; rm -rf /")).toBe(false);
+    expect(validateGitRef("$(whoami)")).toBe(false);
+    expect(validateGitRef("foo`id`")).toBe(false);
+    expect(validateGitRef("foo | cat")).toBe(false);
+    expect(validateGitRef("foo & bg")).toBe(false);
+    expect(validateGitRef("foo > /tmp/x")).toBe(false);
+    expect(validateGitRef("foo < /tmp/x")).toBe(false);
+    expect(validateGitRef("foo\nbar")).toBe(false);
+  });
+});
+
+// ============================================================
+// detectDefaultBranch
+// ============================================================
+
+describe("detectDefaultBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts branch name from symbolic-ref output", () => {
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/develop\n";
+      }
+      return "";
+    });
+    expect(detectDefaultBranch("/tmp/repo")).toBe("develop");
+  });
+
+  it("returns main as fallback when symbolic-ref fails", () => {
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        throw new Error("not a git repository");
+      }
+      return "";
+    });
+    expect(detectDefaultBranch("/tmp/repo")).toBe("main");
+  });
+
+  it("handles master branch", () => {
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/master\n";
+      }
+      return "";
+    });
+    expect(detectDefaultBranch("/tmp/repo")).toBe("master");
+  });
+});
+
+// ============================================================
+// buildRefDiffCommand
+// ============================================================
+
+describe("buildRefDiffCommand", () => {
+  it("both base and head: exact range", () => {
+    expect(buildRefDiffCommand("abc123", "def456")).toBe(
+      "git diff abc123...def456"
+    );
+  });
+
+  it("head only: from merge-base with default branch", () => {
+    expect(buildRefDiffCommand(undefined, "def456")).toBe(
+      "git diff $(git merge-base def456 main)...def456"
+    );
+  });
+
+  it("head only: uses custom default branch", () => {
+    expect(buildRefDiffCommand(undefined, "def456", "develop")).toBe(
+      "git diff $(git merge-base def456 develop)...def456"
+    );
+  });
+
+  it("base only: from base to HEAD", () => {
+    expect(buildRefDiffCommand("abc123", undefined)).toBe(
+      "git diff abc123...HEAD"
+    );
+  });
+});
+
+// ============================================================
+// buildDiffCommand integration
+// ============================================================
+
+function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
+  return {
+    mode: "local",
+    prNumber: 0,
+    baseSha: "",
+    headSha: "",
+    repoRoot: "/tmp/repo",
+    diffelensRoot: "/tmp/diffelens",
+    configPath: ".ai-review.yaml",
+    stateDir: ".ai-review-state",
+    diffTarget: "all",
+    cliBase: undefined,
+    cliHead: undefined,
+    ...overrides,
+  };
+}
+
+describe("buildDiffCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: simulate origin/HEAD → main
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/main\n";
+      }
+      return "";
+    });
+  });
+
+  it("local mode without cliBase/cliHead uses diffTarget", () => {
+    expect(buildDiffCommand(makeOptions({ diffTarget: "staged" }))).toBe(
+      "git diff --cached"
+    );
+    expect(buildDiffCommand(makeOptions({ diffTarget: "branch" }))).toBe(
+      "git diff $(git merge-base HEAD main)...HEAD"
+    );
+  });
+
+  it("branch mode uses detected default branch", () => {
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/master\n";
+      }
+      return "";
+    });
+    expect(buildDiffCommand(makeOptions({ diffTarget: "branch" }))).toBe(
+      "git diff $(git merge-base HEAD master)...HEAD"
+    );
+  });
+
+  it("cliHead uses detected default branch for merge-base", () => {
+    mockedExecSync.mockImplementation((command: string) => {
+      if (typeof command === "string" && command.includes("symbolic-ref")) {
+        return "refs/remotes/origin/develop\n";
+      }
+      return "";
+    });
+    expect(
+      buildDiffCommand(makeOptions({ cliHead: "abc123" }))
+    ).toBe("git diff $(git merge-base abc123 develop)...abc123");
+  });
+
+  it("cliBase/cliHead overrides diffTarget in local mode", () => {
+    expect(
+      buildDiffCommand(makeOptions({ diffTarget: "staged", cliHead: "abc123" }))
+    ).toBe("git diff $(git merge-base abc123 main)...abc123");
+  });
+
+  it("cliBase and cliHead together produce exact range", () => {
+    expect(
+      buildDiffCommand(
+        makeOptions({ cliBase: "def456", cliHead: "abc123" })
+      )
+    ).toBe("git diff def456...abc123");
+  });
+
+  it("github mode ignores cliBase/cliHead", () => {
+    expect(
+      buildDiffCommand(
+        makeOptions({
+          mode: "github",
+          baseSha: "aaa",
+          headSha: "bbb",
+          cliBase: "xxx",
+          cliHead: "yyy",
+        })
+      )
+    ).toBe("git diff aaa...bbb");
+  });
+});

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -19,15 +19,57 @@ export function hashDiff(diff: string): string {
   return createHash("sha256").update(diff).digest("hex").slice(0, 12);
 }
 
-function buildDiffCommand(options: RunOptions): string {
+export function resolveGitRef(ref: string, cwd: string): string {
+  return execSync(`git rev-parse ${ref}`, {
+    encoding: "utf-8",
+    cwd,
+  }).trim();
+}
+
+export function detectDefaultBranch(cwd: string): string {
+  try {
+    const ref = execSync("git symbolic-ref refs/remotes/origin/HEAD", {
+      encoding: "utf-8",
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    // refs/remotes/origin/main → main
+    return ref.replace("refs/remotes/origin/", "");
+  } catch {
+    return "main";
+  }
+}
+
+export function buildDiffCommand(options: RunOptions): string {
   if (options.mode === "github") {
     return `git diff ${options.baseSha}...${options.headSha}`;
   }
 
-  return localDiffCommand(options.diffTarget);
+  const defaultBranch = detectDefaultBranch(options.repoRoot);
+
+  if (options.cliBase || options.cliHead) {
+    return buildRefDiffCommand(options.cliBase, options.cliHead, defaultBranch);
+  }
+
+  return localDiffCommand(options.diffTarget, defaultBranch);
 }
 
-function localDiffCommand(target: DiffTarget): string {
+export function buildRefDiffCommand(
+  base: string | undefined,
+  head: string | undefined,
+  defaultBranch: string = "main"
+): string {
+  if (base && head) {
+    return `git diff ${base}...${head}`;
+  }
+  if (head) {
+    return `git diff $(git merge-base ${head} ${defaultBranch})...${head}`;
+  }
+  // base only — diff from base to current HEAD
+  return `git diff ${base}...HEAD`;
+}
+
+function localDiffCommand(target: DiffTarget, defaultBranch: string): string {
   switch (target) {
     case "staged":
       return "git diff --cached";
@@ -36,7 +78,7 @@ function localDiffCommand(target: DiffTarget): string {
     case "all":
       return "git diff HEAD";
     case "branch":
-      return "git diff $(git merge-base HEAD main)...HEAD";
+      return `git diff $(git merge-base HEAD ${defaultBranch})...HEAD`;
     case "commits":
       return "git diff HEAD~1...HEAD";
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import {
 import { checkAvailability, type Finding } from "./adapters/index.js";
 import { filterDiffByExcludePatterns } from "./filters.js";
 import { resolveOptions, type RunOptions } from "./options.js";
-import { fetchDiff, hashDiff } from "./diff.js";
+import { fetchDiff, hashDiff, resolveGitRef } from "./diff.js";
 import { collectProjectContext, formatProjectContext } from "./project-context.js";
 import { resolvePrompt, validatePrompts } from "./prompt-resolver.js";
 
@@ -82,9 +82,24 @@ export async function main(options?: RunOptions) {
     return;
   }
 
-  // For local mode, compute headSha from diff hash
-  const headSha = opts.mode === "local" ? hashDiff(diff) : opts.headSha;
-  const baseSha = opts.baseSha;
+  // Resolve SHAs for state tracking
+  let headSha: string;
+  if (opts.mode === "github") {
+    headSha = opts.headSha;
+  } else if (opts.cliHead) {
+    headSha = resolveGitRef(opts.cliHead, opts.repoRoot);
+  } else {
+    headSha = hashDiff(diff);
+  }
+
+  let baseSha: string;
+  if (opts.mode === "github") {
+    baseSha = opts.baseSha;
+  } else if (opts.cliBase) {
+    baseSha = resolveGitRef(opts.cliBase, opts.repoRoot);
+  } else {
+    baseSha = opts.baseSha;
+  }
 
   // 4. Previous round state
   const state = await loadOrCreateState(

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,15 +17,39 @@ export interface RunOptions {
   configPath: string;
   stateDir: string;
   diffTarget: DiffTarget;
+  cliBase: string | undefined;
+  cliHead: string | undefined;
+}
+
+// Reject shell metacharacters to prevent command injection
+export function validateGitRef(ref: string): boolean {
+  return ref.length > 0 && !/[;&|`$(){}!<>\n\r]/.test(ref);
 }
 
 export function resolveOptions(): RunOptions {
   const args = process.argv.slice(2);
 
   const mode = parseArg(args, "--mode") ?? detectMode();
-  const diffTarget = (parseArg(args, "--diff-target") ?? "all") as DiffTarget;
+  const explicitDiffTarget = parseArg(args, "--diff-target");
+  const diffTarget = (explicitDiffTarget ?? "all") as DiffTarget;
   const stateDir = parseArg(args, "--state-dir") ?? defaultStateDir(mode);
   const configPath = parseArg(args, "--config") ?? (process.env.CONFIG_PATH ?? ".ai-review.yaml");
+
+  const cliBase = parseArg(args, "--base");
+  const cliHead = parseArg(args, "--head");
+
+  if (cliBase !== undefined && !validateGitRef(cliBase)) {
+    console.error(`Invalid git ref for --base: "${cliBase}"`);
+    process.exit(1);
+  }
+  if (cliHead !== undefined && !validateGitRef(cliHead)) {
+    console.error(`Invalid git ref for --head: "${cliHead}"`);
+    process.exit(1);
+  }
+
+  if (explicitDiffTarget && (cliBase || cliHead)) {
+    console.warn("--base/--head provided; --diff-target will be ignored");
+  }
 
   const diffelensRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const repoRoot = process.cwd();
@@ -41,6 +65,8 @@ export function resolveOptions(): RunOptions {
       configPath,
       stateDir,
       diffTarget,
+      cliBase,
+      cliHead,
     };
   }
 
@@ -54,6 +80,8 @@ export function resolveOptions(): RunOptions {
     configPath,
     stateDir,
     diffTarget,
+    cliBase,
+    cliHead,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `--base <ref>` and `--head <ref>` CLI options for flexible commit-range diff targeting in local mode
- Auto-detect default branch via `git symbolic-ref refs/remotes/origin/HEAD` (supports `master`, `develop`, etc.) with `main` fallback
- Add `validateGitRef()` to reject shell metacharacters for command injection prevention
- Document Local Mode usage and CLI options table in README

## Usage
```bash
# Review up to a specific commit
npx tsx src/main.ts --head abc1234

# Review a specific commit range
npx tsx src/main.ts --base def5678 --head abc1234

# Review from a specific base to current HEAD
npx tsx src/main.ts --base def5678
```

## Test plan
- [x] `validateGitRef` — valid refs accepted, shell metacharacters rejected
- [x] `buildRefDiffCommand` — correct git command for all 3 cases (both/head-only/base-only)
- [x] `buildDiffCommand` — `cliBase`/`cliHead` overrides `diffTarget`, github mode unaffected
- [x] `detectDefaultBranch` — extracts branch name, falls back to `main` on error
- [x] All 138 existing + new tests pass