### PR TITLE
feat: replace artifact-based state with comment-embedded state

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -36,15 +36,7 @@ jobs:
       - name: Install orchestrator dependencies
         run: npm ci
 
-      # Restore state from previous round
-      - name: Download review state
-        uses: actions/download-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.pull_request.number }}
-          path: .ai-review-state/
-        continue-on-error: true
-
-      # Run review
+      # Run review (state is persisted in the PR comment)
       - name: Run AI Review
         run: npx tsx src/main.ts
         env:
@@ -57,11 +49,3 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           CONFIG_PATH: ${{ github.workspace }}/.ai-review.yaml
-
-      # Save state (used in next round)
-      - name: Upload review state
-        uses: actions/upload-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.pull_request.number }}
-          path: .ai-review-state/
-          overwrite: true

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -56,14 +56,6 @@ jobs:
       - name: Install orchestrator dependencies
         run: npm ci
 
-      # Restore state from previous round
-      - name: Download review state
-        uses: actions/download-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.pull_request.number }}
-          path: .ai-review-state/
-        continue-on-error: true
-
       - name: Run AI Review
         run: npx tsx src/main.ts
         env:
@@ -74,14 +66,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           CONFIG_PATH: ${{ github.workspace }}/.ai-review.yaml
-
-      # Save state for next round
-      - name: Upload review state
-        uses: actions/upload-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.pull_request.number }}
-          path: .ai-review-state/
-          overwrite: true
 ```
 
 ### Gemini Workflow
@@ -154,13 +138,13 @@ See [Local Mode Guide — Configuration](./local-mode.md#configuration) for full
 
 ## State Management
 
-diffelens uses **GitHub Actions artifacts** for cross-round state persistence:
+diffelens uses **comment-embedded state** for cross-round persistence in GitHub mode. Review state is encoded as a hidden HTML marker (`<!-- ai-review-state: {base64} -->`) at the end of the summary comment. No artifacts or external storage are needed.
 
-1. **Download step**: restores `review_state.json` from a previous workflow run (if any)
-2. **Review step**: reads prior findings, runs lenses, deduplicates, and updates state
-3. **Upload step**: saves updated state as an artifact for the next round
+1. On each workflow run, diffelens searches for the existing summary comment
+2. If found, it extracts the embedded state and advances the round if `HEAD_SHA` changed
+3. After review, the updated state is re-embedded into the comment
 
-The artifact is named `review-state-pr-{number}` and uses `overwrite: true` to always keep the latest state.
+This approach is more reliable than GitHub Actions artifacts, which can silently fail on upload.
 
 ### How Rounds Work
 
@@ -208,13 +192,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download review state
-        uses: actions/download-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.issue.number }}
-          path: .ai-review-state/
-        continue-on-error: true
-
       - name: Handle command
         run: npx tsx src/handle-command.ts
         env:
@@ -224,13 +201,6 @@ jobs:
           COMMAND_BODY: ${{ github.event.comment.body }}
           COMMAND_USER: ${{ github.event.comment.user.login }}
           COMMENT_ID: ${{ github.event.comment.id }}
-
-      - name: Upload review state
-        uses: actions/upload-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.issue.number }}
-          path: .ai-review-state/
-          overwrite: true
 ```
 
 ## Troubleshooting
@@ -264,10 +234,9 @@ Check that `fetch-depth: 0` is set in the checkout step. Without full history, `
 
 ### State Not Persisting
 
-Artifacts expire after 90 days by default. If state is lost between rounds, ensure:
-- The artifact name matches: `review-state-pr-{number}`
-- `overwrite: true` is set in the upload step
-- The download step has `continue-on-error: true` (first run has no artifact)
+Review state is embedded in the PR summary comment. If state is lost between rounds:
+- Ensure `GITHUB_TOKEN` has `pull-requests: write` permission
+- Check that the summary comment (with `<!-- ai-review-summary -->` marker) exists and hasn't been deleted
 
 ### Lenses Skipped
 

--- a/src/__tests__/review-state.test.ts
+++ b/src/__tests__/review-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { updateState, linesOverlap, generateFindingId } from "../state/review-state.js";
+import { updateState, linesOverlap, generateFindingId, advanceRoundIfNeeded } from "../state/review-state.js";
 import type { ReviewState } from "../state/review-state.js";
 import type { Finding } from "../adapters/types.js";
 
@@ -60,6 +60,29 @@ describe("generateFindingId", () => {
     expect(generateFindingId("readability", 0)).toBe("r-001");
     expect(generateFindingId("architectural", 4)).toBe("a-005");
     expect(generateFindingId("bug_risk", 99)).toBe("b-100");
+  });
+});
+
+describe("advanceRoundIfNeeded", () => {
+  it("increments round when head_sha changes", () => {
+    const state = makeState({ current_round: 1, head_sha: "aaa" });
+    const result = advanceRoundIfNeeded(state, "bbb");
+    expect(result.current_round).toBe(2);
+    expect(result.head_sha).toBe("bbb");
+  });
+
+  it("returns same state when head_sha is unchanged", () => {
+    const state = makeState({ current_round: 1, head_sha: "aaa" });
+    const result = advanceRoundIfNeeded(state, "aaa");
+    expect(result.current_round).toBe(1);
+    expect(result).toBe(state); // same reference
+  });
+
+  it("does not mutate original state", () => {
+    const state = makeState({ current_round: 1, head_sha: "aaa" });
+    advanceRoundIfNeeded(state, "bbb");
+    expect(state.current_round).toBe(1);
+    expect(state.head_sha).toBe("aaa");
   });
 });
 

--- a/src/__tests__/summary-renderer.test.ts
+++ b/src/__tests__/summary-renderer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { renderSummary, MARKER, embedState, extractState } from "../output/summary-renderer.js";
+import { renderSummary, MARKER } from "../output/summary-renderer.js";
+import { embedState, extractState } from "../output/comment-state.js";
 import type { ReviewState } from "../state/review-state.js";
 
 function makeState(overrides: Partial<ReviewState> = {}): ReviewState {

--- a/src/__tests__/summary-renderer.test.ts
+++ b/src/__tests__/summary-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderSummary, MARKER } from "../output/summary-renderer.js";
+import { renderSummary, MARKER, embedState, extractState } from "../output/summary-renderer.js";
 import type { ReviewState } from "../state/review-state.js";
 
 function makeState(overrides: Partial<ReviewState> = {}): ReviewState {
@@ -118,5 +118,83 @@ describe("renderSummary", () => {
     });
     const result = renderSummary(state, "request_changes");
     expect(result).toContain("use camelCase");
+  });
+});
+
+describe("embedState / extractState", () => {
+  it("round-trips state through embed and extract", () => {
+    const state = makeState({
+      current_round: 2,
+      findings: [
+        {
+          id: "b-001",
+          lens: "bug_risk",
+          status: "open",
+          severity: "blocker",
+          file: "src/app.ts",
+          line_start: 10,
+          line_end: 10,
+          category: "null_check",
+          summary: "missing null check",
+          suggestion: "add check",
+          first_raised_round: 1,
+          last_evaluated_round: 2,
+          resolution_note: null,
+        },
+      ],
+    });
+    const body = "## Summary\nSome content here";
+    const embedded = embedState(body, state);
+
+    const extracted = extractState(embedded);
+    expect(extracted).not.toBeNull();
+    expect(extracted!.current_round).toBe(2);
+    expect(extracted!.findings).toHaveLength(1);
+    expect(extracted!.findings[0].id).toBe("b-001");
+  });
+
+  it("returns null when no state marker is present", () => {
+    const body = "## Summary\nNo state here";
+    expect(extractState(body)).toBeNull();
+  });
+
+  it("returns null for malformed base64", () => {
+    const body = "## Summary\n<!-- ai-review-state: !!!invalid!!! -->";
+    expect(extractState(body)).toBeNull();
+  });
+
+  it("preserves original body content before the marker", () => {
+    const state = makeState();
+    const body = "## Summary\nContent";
+    const embedded = embedState(body, state);
+
+    expect(embedded).toContain("## Summary");
+    expect(embedded).toContain("Content");
+    expect(embedded).toContain("<!-- ai-review-state: ");
+  });
+
+  it("handles state with unicode content", () => {
+    const state = makeState({
+      findings: [
+        {
+          id: "r-001",
+          lens: "readability",
+          status: "open",
+          severity: "warning",
+          file: "src/日本語.ts",
+          line_start: 1,
+          line_end: 1,
+          category: "naming",
+          summary: "変数名が不適切",
+          suggestion: "キャメルケースを使用",
+          first_raised_round: 1,
+          last_evaluated_round: 1,
+          resolution_note: null,
+        },
+      ],
+    });
+    const embedded = embedState("body", state);
+    const extracted = extractState(embedded);
+    expect(extracted!.findings[0].summary).toBe("変数名が不適切");
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,7 +108,12 @@ export async function main(options?: RunOptions) {
   let state: Awaited<ReturnType<typeof loadOrCreateState>>;
   if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
     // GitHub mode: load state from PR comment
-    const commentState = await loadStateFromComment(opts.prNumber);
+    let commentState: Awaited<ReturnType<typeof loadStateFromComment>> = null;
+    try {
+      commentState = await loadStateFromComment(opts.prNumber);
+    } catch (e) {
+      console.warn(`  Failed to load state from comment, starting fresh: ${e}`);
+    }
     state = commentState
       ? advanceRoundIfNeeded(commentState, headSha)
       : createInitialState(opts.prNumber, baseSha, headSha, config.global.max_rounds);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { loadConfig, loadConfigWithFallback } from "./config.js";
 import { runLens, type LensRunResult } from "./lens-runner.js";
 import {
   loadOrCreateState,
+  createInitialState,
+  advanceRoundIfNeeded,
   updateState,
   saveState,
 } from "./state/review-state.js";
@@ -15,6 +17,7 @@ import {
 import {
   upsertSummaryComment,
   postEscalationComment,
+  loadStateFromComment,
 } from "./output/github-client.js";
 import { checkAvailability, type Finding } from "./adapters/index.js";
 import { filterDiffByExcludePatterns } from "./filters.js";
@@ -102,13 +105,23 @@ export async function main(options?: RunOptions) {
   }
 
   // 4. Previous round state
-  const state = await loadOrCreateState(
-    opts.stateDir,
-    opts.prNumber,
-    baseSha,
-    headSha,
-    config.global.max_rounds
-  );
+  let state: Awaited<ReturnType<typeof loadOrCreateState>>;
+  if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
+    // GitHub mode: load state from PR comment
+    const commentState = await loadStateFromComment(opts.prNumber);
+    state = commentState
+      ? advanceRoundIfNeeded(commentState, headSha)
+      : createInitialState(opts.prNumber, baseSha, headSha, config.global.max_rounds);
+  } else {
+    // Local mode: load state from file
+    state = await loadOrCreateState(
+      opts.stateDir,
+      opts.prNumber,
+      baseSha,
+      headSha,
+      config.global.max_rounds
+    );
+  }
   console.log(`Round: ${state.current_round}/${state.max_rounds}`);
   console.log(
     `  Previous findings: ${state.findings.length} (open: ${state.findings.filter((f) => f.status === "open").length})\n`
@@ -117,10 +130,12 @@ export async function main(options?: RunOptions) {
   // 5. Convergence check (max_rounds exceeded)
   if (state.current_round > state.max_rounds) {
     console.log("Max rounds exceeded. Escalating to human reviewer.");
-    if (opts.mode === "github") {
+    if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
       await postEscalationComment(opts.prNumber, state);
     }
-    await saveState(opts.stateDir, state);
+    if (opts.mode === "local") {
+      await saveState(opts.stateDir, state);
+    }
     return;
   }
 
@@ -223,8 +238,10 @@ export async function main(options?: RunOptions) {
     console.log(renderSummary(newState, decision, opts.mode));
   }
 
-  // 13. Save state
-  await saveState(opts.stateDir, newState);
+  // 13. Save state (local mode only; GitHub mode persists via comment)
+  if (opts.mode === "local") {
+    await saveState(opts.stateDir, newState);
+  }
 
   console.log("\nAI Review — Done.");
 }

--- a/src/output/comment-state.ts
+++ b/src/output/comment-state.ts
@@ -1,0 +1,33 @@
+import type { ReviewState } from "../state/review-state.js";
+
+// ============================================================
+// State embedding/extraction for PR comments (GitHub mode)
+// ============================================================
+
+const STATE_MARKER_PREFIX = "<!-- ai-review-state: ";
+const STATE_MARKER_SUFFIX = " -->";
+
+/** Embed review state as a hidden marker at the end of the comment body */
+export function embedState(body: string, state: ReviewState): string {
+  const json = JSON.stringify(state);
+  const encoded = Buffer.from(json, "utf-8").toString("base64");
+  return `${body}\n${STATE_MARKER_PREFIX}${encoded}${STATE_MARKER_SUFFIX}`;
+}
+
+/** Extract review state from comment body. Returns null if no marker found. */
+export function extractState(body: string): ReviewState | null {
+  const startIdx = body.indexOf(STATE_MARKER_PREFIX);
+  if (startIdx === -1) return null;
+
+  const dataStart = startIdx + STATE_MARKER_PREFIX.length;
+  const endIdx = body.indexOf(STATE_MARKER_SUFFIX, dataStart);
+  if (endIdx === -1) return null;
+
+  const encoded = body.slice(dataStart, endIdx);
+  try {
+    const json = Buffer.from(encoded, "base64").toString("utf-8");
+    return JSON.parse(json) as ReviewState;
+  } catch {
+    return null;
+  }
+}

--- a/src/output/github-client.ts
+++ b/src/output/github-client.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import type { ReviewState } from "../state/review-state.js";
 import type { ReviewDecision } from "../convergence.js";
-import { renderSummary, MARKER } from "./summary-renderer.js";
+import { renderSummary, MARKER, embedState, extractState } from "./summary-renderer.js";
 
 // ============================================================
 // GitHub API: post and update summary comments
@@ -26,7 +26,31 @@ export function parseRepo(): { owner: string; repo: string } {
 }
 
 /**
+ * Load review state from the existing summary comment.
+ * Returns null if no comment or no embedded state found.
+ */
+export async function loadStateFromComment(
+  prNumber: number
+): Promise<ReviewState | null> {
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo();
+
+  const commentId = await findSummaryComment(octokit, owner, repo, prNumber);
+  if (!commentId) return null;
+
+  const { data: comment } = await octokit.issues.getComment({
+    owner,
+    repo,
+    comment_id: commentId,
+  });
+
+  if (!comment.body) return null;
+  return extractState(comment.body);
+}
+
+/**
  * Post or update a summary comment (search for existing by marker).
+ * Embeds review state as a hidden marker for cross-round persistence.
  */
 export async function upsertSummaryComment(
   prNumber: number,
@@ -35,7 +59,8 @@ export async function upsertSummaryComment(
 ): Promise<void> {
   const octokit = getOctokit();
   const { owner, repo } = parseRepo();
-  const body = renderSummary(state, decision);
+  const rendered = renderSummary(state, decision);
+  const body = embedState(rendered, state);
 
   // Search for existing summary comment
   const existingCommentId = await findSummaryComment(
@@ -95,7 +120,7 @@ export async function postEscalationComment(
     (f) => f.status === "open" && f.severity === "blocker"
   );
 
-  const body = [
+  const rendered = [
     MARKER,
     `## 🚨 AI Review — Escalated`,
     "",
@@ -110,6 +135,7 @@ export async function postEscalationComment(
         `- **[${f.id}]** \`${f.file}:${f.line_start}\` — ${f.summary}`
     ),
   ].join("\n");
+  const body = embedState(rendered, state);
 
   const existingCommentId = await findSummaryComment(
     octokit,

--- a/src/output/github-client.ts
+++ b/src/output/github-client.ts
@@ -1,7 +1,8 @@
 import { Octokit } from "@octokit/rest";
 import type { ReviewState } from "../state/review-state.js";
 import type { ReviewDecision } from "../convergence.js";
-import { renderSummary, MARKER, embedState, extractState } from "./summary-renderer.js";
+import { renderSummary, MARKER } from "./summary-renderer.js";
+import { embedState, extractState } from "./comment-state.js";
 
 // ============================================================
 // GitHub API: post and update summary comments

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -146,5 +146,37 @@ function renderFinding(f: StateFinding, currentRound: number): string[] {
   return lines;
 }
 
+// ============================================================
+// State embedding in PR comments (GitHub mode)
+// ============================================================
+
+const STATE_MARKER_PREFIX = "<!-- ai-review-state: ";
+const STATE_MARKER_SUFFIX = " -->";
+
+/** Embed review state as a hidden marker at the end of the comment body */
+export function embedState(body: string, state: ReviewState): string {
+  const json = JSON.stringify(state);
+  const encoded = Buffer.from(json, "utf-8").toString("base64");
+  return `${body}\n${STATE_MARKER_PREFIX}${encoded}${STATE_MARKER_SUFFIX}`;
+}
+
+/** Extract review state from comment body. Returns null if no marker found. */
+export function extractState(body: string): ReviewState | null {
+  const startIdx = body.indexOf(STATE_MARKER_PREFIX);
+  if (startIdx === -1) return null;
+
+  const dataStart = startIdx + STATE_MARKER_PREFIX.length;
+  const endIdx = body.indexOf(STATE_MARKER_SUFFIX, dataStart);
+  if (endIdx === -1) return null;
+
+  const encoded = body.slice(dataStart, endIdx);
+  try {
+    const json = Buffer.from(encoded, "base64").toString("utf-8");
+    return JSON.parse(json) as ReviewState;
+  } catch {
+    return null;
+  }
+}
+
 /** Marker to identify the summary comment */
 export { MARKER };

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -146,37 +146,5 @@ function renderFinding(f: StateFinding, currentRound: number): string[] {
   return lines;
 }
 
-// ============================================================
-// State embedding in PR comments (GitHub mode)
-// ============================================================
-
-const STATE_MARKER_PREFIX = "<!-- ai-review-state: ";
-const STATE_MARKER_SUFFIX = " -->";
-
-/** Embed review state as a hidden marker at the end of the comment body */
-export function embedState(body: string, state: ReviewState): string {
-  const json = JSON.stringify(state);
-  const encoded = Buffer.from(json, "utf-8").toString("base64");
-  return `${body}\n${STATE_MARKER_PREFIX}${encoded}${STATE_MARKER_SUFFIX}`;
-}
-
-/** Extract review state from comment body. Returns null if no marker found. */
-export function extractState(body: string): ReviewState | null {
-  const startIdx = body.indexOf(STATE_MARKER_PREFIX);
-  if (startIdx === -1) return null;
-
-  const dataStart = startIdx + STATE_MARKER_PREFIX.length;
-  const endIdx = body.indexOf(STATE_MARKER_SUFFIX, dataStart);
-  if (endIdx === -1) return null;
-
-  const encoded = body.slice(dataStart, endIdx);
-  try {
-    const json = Buffer.from(encoded, "base64").toString("utf-8");
-    return JSON.parse(json) as ReviewState;
-  } catch {
-    return null;
-  }
-}
-
 /** Marker to identify the summary comment */
 export { MARKER };

--- a/src/state/review-state.ts
+++ b/src/state/review-state.ts
@@ -75,17 +75,7 @@ export async function loadOrCreateState(
     try {
       const content = await readFile(filePath, "utf-8");
       const state = JSON.parse(content) as ReviewState;
-
-      // If head_sha changed, start a new round (return new object immutably)
-      if (state.head_sha !== headSha) {
-        return {
-          ...state,
-          current_round: state.current_round + 1,
-          head_sha: headSha,
-        };
-      }
-
-      return state;
+      return advanceRoundIfNeeded(state, headSha);
     } catch {
       console.warn(`Failed to parse state file, creating new state`);
     }
@@ -94,7 +84,7 @@ export async function loadOrCreateState(
   return createInitialState(prNumber, baseSha, headSha, maxRounds);
 }
 
-function createInitialState(
+export function createInitialState(
   prNumber: number,
   baseSha: string,
   headSha: string,
@@ -112,6 +102,21 @@ function createInitialState(
     round_history: [],
     decisions: [],
   };
+}
+
+/** Advance round if head_sha changed (immutable) */
+export function advanceRoundIfNeeded(
+  state: ReviewState,
+  headSha: string
+): ReviewState {
+  if (state.head_sha !== headSha) {
+    return {
+      ...state,
+      current_round: state.current_round + 1,
+      head_sha: headSha,
+    };
+  }
+  return state;
 }
 
 /** Update state with new findings (immutable) */


### PR DESCRIPTION
## Summary

- Migrate GitHub mode state persistence from Actions artifacts to hidden HTML markers (`<!-- ai-review-state: {base64} -->`) embedded in the PR summary comment
- Artifacts silently fail on upload, causing rounds to stay at 1 forever — this approach is more reliable
- Local mode retains file-based state (no change)

## Changes

- `src/output/summary-renderer.ts`: Add `embedState()` / `extractState()` for base64 state encoding
- `src/output/github-client.ts`: Add `loadStateFromComment()`, embed state in `upsertSummaryComment()` / `postEscalationComment()`
- `src/state/review-state.ts`: Export `createInitialState()`, add `advanceRoundIfNeeded()` helper
- `src/main.ts`: Split state loading — comment-based (github) vs file-based (local)
- `.github/workflows/ai-review.yml`: Remove artifact download/upload steps
- `docs/github-actions.md`: Update State Management section

## Test plan

- [x] `npm test` — all 146 tests pass (10 new tests added)
- [ ] Local mode: `npx tsx src/main.ts --diff-target branch` works with file-based state
- [ ] PR workflow: comment contains embedded state marker after review
- [ ] Second push: round advances to 2

Closes #5