### PR TITLE
feat: support .ai-review.local.yaml for local mode overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .ai-review-state/
+.ai-review.local.yaml
 .env*
 *.log
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Multi-lens AI PR review orchestrator. Uses Claude Code CLI / Codex CLI as the ex
 ## Configuration
 - Config path: `--config` arg → `CONFIG_PATH` env var → `.ai-review.yaml` (cwd)
 - Local mode fallback: diffelens bundled `.ai-review.yaml` if repo has none
+- **Local overlay**: `.ai-review.local.yaml` is auto-detected in local mode and deep-merged over the base config. Only specified fields are overridden. Skipped when `--config` is explicitly provided. Use this to run different CLI/model settings locally (e.g., Claude Opus) vs CI (e.g., Gemini Flash)
 - Convergence: `round_severities` array (N rounds) or legacy `round_N_severities` (auto-normalized)
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Multi-lens AI PR review orchestrator using LLM CLI tools such as Claude Code / C
 
 - **Lens Separation**: readability / architectural / bug_risk run as separate LLM invocations
 - **Context Control**: readability receives only the diff; architectural allows full repository exploration
-- **State Management**: `review_state.json` tracks findings across rounds and prevents contradictions
+- **State Management**: Findings tracked across rounds — comment-embedded (GitHub) or file-based (local)
 - **Convergence Control**: Round limit + progressive severity filtering prevents endless review loops
 - **CLI Abstraction**: Claude Code / Codex / Gemini can be swapped via adapter pattern
 
@@ -68,6 +68,7 @@ src/
 │   └── review-state.ts  # State management
 └── output/
     ├── summary-renderer.ts  # Markdown summary generation
+    ├── comment-state.ts     # State embedding in PR comments
     └── github-client.ts     # GitHub API client
 prompts/
 ├── readability.md

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -78,6 +78,41 @@ npx tsx src/test-lens.ts bug_risk
 
 Place `.ai-review.yaml` at the repository root. If no config exists in the target repo, diffelens uses its own bundled default config.
 
+### Local Config Overlay
+
+You can override settings for local development by creating `.ai-review.local.yaml` alongside `.ai-review.yaml`. In local mode, diffelens auto-detects this file and deep-merges it over the base config. Only specify fields you want to override — everything else is inherited.
+
+```yaml
+# .ai-review.local.yaml — use Claude locally instead of Gemini
+global:
+  default_cli: "claude"
+
+lenses:
+  readability:
+    cli: "claude"
+    model: "claude-opus-4-6"
+  architectural:
+    cli: "claude"
+    model: "claude-opus-4-6"
+  bug_risk:
+    cli: "claude"
+    model: "claude-opus-4-6"
+```
+
+**Merge rules:**
+
+| Field | Strategy |
+|-------|----------|
+| `global.*` | Field-level overwrite |
+| `lenses.<name>.*` | Per-lens field-level overwrite |
+| `convergence.*` | Field-level overwrite |
+| `filters.exclude_patterns` | Array replacement (not appended) |
+
+**Notes:**
+- `.ai-review.local.yaml` is gitignored by default
+- Skipped when `--config` is explicitly provided
+- Only applied in local mode (GitHub Actions always uses `.ai-review.yaml`)
+
 ### Default Config (Claude Code)
 
 ```yaml

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { loadConfig } from "../config.js";
+import { loadConfig, deepMergeRawConfig, loadConfigWithLocalOverlay } from "../config.js";
 import { writeFile, mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -285,5 +285,232 @@ describe("loadConfig convergence normalization", () => {
   approve_condition: "zero_blockers"`));
 
     await expect(loadConfig(path)).rejects.toThrow('Invalid severity "critical"');
+  });
+});
+
+// ============================================================
+// deepMergeRawConfig
+// ============================================================
+
+function makeRawConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "1.0",
+    global: {
+      max_rounds: 3,
+      language: "en",
+      default_cli: "gemini" as const,
+      timeout_ms: 120000,
+    },
+    lenses: {
+      readability: {
+        enabled: true,
+        cli: "gemini" as const,
+        model: "gemini-2.5-flash",
+        isolation: "tempdir" as const,
+        tool_policy: "none" as const,
+        timeout_ms: 300000,
+        severity_cap: "warning" as const,
+      },
+      architectural: {
+        enabled: true,
+        cli: "gemini" as const,
+        model: "gemini-2.5-flash",
+        isolation: "repo" as const,
+        tool_policy: "none" as const,
+      },
+    },
+    convergence: {
+      round_severities: [["blocker", "warning", "nitpick"], ["blocker", "warning"], ["blocker"]],
+      approve_condition: "zero_blockers" as const,
+    },
+    filters: { exclude_patterns: ["**/*.lock"] },
+    ...overrides,
+  };
+}
+
+describe("deepMergeRawConfig", () => {
+  it("overrides only global.default_cli when specified", () => {
+    const base = makeRawConfig();
+    const overlay = { global: { default_cli: "claude" } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.global.default_cli).toBe("claude");
+    expect(merged.global.max_rounds).toBe(3);
+    expect(merged.global.timeout_ms).toBe(120000);
+  });
+
+  it("overrides only model for a specific lens", () => {
+    const base = makeRawConfig();
+    const overlay = { lenses: { readability: { model: "claude-opus-4-6" } } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.lenses.readability.model).toBe("claude-opus-4-6");
+    expect(merged.lenses.readability.cli).toBe("gemini");
+    expect(merged.lenses.readability.isolation).toBe("tempdir");
+    expect(merged.lenses.architectural.model).toBe("gemini-2.5-flash");
+  });
+
+  it("adds a new lens from overlay", () => {
+    const base = makeRawConfig();
+    const overlay = {
+      lenses: {
+        security: {
+          enabled: true,
+          model: "claude-opus-4-6",
+          isolation: "repo",
+          tool_policy: "none",
+          prompt_file: "prompts/security.md",
+        },
+      },
+    };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.lenses).toHaveProperty("security");
+    expect((merged.lenses as Record<string, unknown>)["security"]).toMatchObject({
+      enabled: true,
+      model: "claude-opus-4-6",
+    });
+    expect(merged.lenses.readability).toBeDefined();
+  });
+
+  it("overrides convergence.approve_condition only", () => {
+    const base = makeRawConfig();
+    const overlay = { convergence: { approve_condition: "zero_blockers_and_warnings" } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.convergence.approve_condition).toBe("zero_blockers_and_warnings");
+    expect((merged.convergence as { round_severities: string[][] }).round_severities).toHaveLength(3);
+  });
+
+  it("replaces filters.exclude_patterns entirely", () => {
+    const base = makeRawConfig();
+    const overlay = { filters: { exclude_patterns: ["**/*.min.js", "**/vendor/**"] } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.filters.exclude_patterns).toEqual(["**/*.min.js", "**/vendor/**"]);
+  });
+
+  it("returns base unchanged when overlay is empty", () => {
+    const base = makeRawConfig();
+    const merged = deepMergeRawConfig(base, {});
+
+    expect(merged.global).toEqual(base.global);
+    expect(merged.lenses).toEqual(base.lenses);
+    expect(merged.convergence).toEqual(base.convergence);
+    expect(merged.filters).toEqual(base.filters);
+  });
+
+  it("can disable a lens via overlay", () => {
+    const base = makeRawConfig();
+    const overlay = { lenses: { readability: { enabled: false } } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.lenses.readability.enabled).toBe(false);
+  });
+
+  it("does not mutate the base config", () => {
+    const base = makeRawConfig();
+    const originalCli = base.global.default_cli;
+    deepMergeRawConfig(base, { global: { default_cli: "claude" } });
+
+    expect(base.global.default_cli).toBe(originalCli);
+  });
+});
+
+// ============================================================
+// loadConfigWithLocalOverlay
+// ============================================================
+
+async function writeYamlFile(dir: string, filename: string, yaml: string): Promise<string> {
+  const path = join(dir, filename);
+  await writeFile(path, yaml, "utf-8");
+  return path;
+}
+
+describe("loadConfigWithLocalOverlay", () => {
+  it("applies local overlay when file exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-overlay-test-"));
+    tempDirs.push(dir);
+
+    await writeYamlFile(dir, ".ai-review.yaml", FULL_YAML);
+    await writeYamlFile(dir, ".ai-review.local.yaml", `
+global:
+  default_cli: "claude"
+lenses:
+  readability:
+    cli: "claude"
+    model: "claude-opus-4-6"
+`);
+
+    const basePath = join(dir, ".ai-review.yaml");
+    const localPath = join(dir, ".ai-review.local.yaml");
+    const { config, localOverlayApplied } = await loadConfigWithLocalOverlay(basePath, localPath);
+
+    expect(localOverlayApplied).toBe(true);
+    expect(config.global.default_cli).toBe("claude");
+    const readability = config.lenses.find((l) => l.name === "readability");
+    expect(readability?.cli).toBe("claude");
+    expect(readability?.model).toBe("claude-opus-4-6");
+    // Unchanged lens
+    const architectural = config.lenses.find((l) => l.name === "architectural");
+    expect(architectural?.cli).toBe("claude"); // default_cli changed to claude
+    expect(architectural?.model).toBe("claude-opus-4-6");
+  });
+
+  it("returns base config when local file does not exist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-overlay-test-"));
+    tempDirs.push(dir);
+
+    await writeYamlFile(dir, ".ai-review.yaml", FULL_YAML);
+
+    const basePath = join(dir, ".ai-review.yaml");
+    const localPath = join(dir, ".ai-review.local.yaml");
+    const { config, localOverlayApplied } = await loadConfigWithLocalOverlay(basePath, localPath);
+
+    expect(localOverlayApplied).toBe(false);
+    expect(config.global.default_cli).toBe("claude");
+    expect(config.lenses).toHaveLength(3);
+  });
+
+  it("validates merged config (invalid after merge throws)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-overlay-test-"));
+    tempDirs.push(dir);
+
+    await writeYamlFile(dir, ".ai-review.yaml", FULL_YAML);
+    await writeYamlFile(dir, ".ai-review.local.yaml", `
+convergence:
+  round_severities: []
+  approve_condition: "zero_blockers"
+`);
+
+    const basePath = join(dir, ".ai-review.yaml");
+    const localPath = join(dir, ".ai-review.local.yaml");
+    await expect(loadConfigWithLocalOverlay(basePath, localPath)).rejects.toThrow(
+      "round_severities must not be empty"
+    );
+  });
+
+  it("overrides cli and model per lens for local use", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-overlay-test-"));
+    tempDirs.push(dir);
+
+    await writeYamlFile(dir, ".ai-review.yaml", FULL_YAML);
+    await writeYamlFile(dir, ".ai-review.local.yaml", `
+lenses:
+  bug_risk:
+    cli: "gemini"
+    model: "gemini-2.5-pro"
+`);
+
+    const basePath = join(dir, ".ai-review.yaml");
+    const localPath = join(dir, ".ai-review.local.yaml");
+    const { config } = await loadConfigWithLocalOverlay(basePath, localPath);
+
+    const bugRisk = config.lenses.find((l) => l.name === "bug_risk");
+    expect(bugRisk?.cli).toBe("gemini");
+    expect(bugRisk?.model).toBe("gemini-2.5-pro");
+    // Other lenses unchanged
+    const readability = config.lenses.find((l) => l.name === "readability");
+    expect(readability?.cli).toBe("claude");
   });
 });

--- a/src/__tests__/diff.test.ts
+++ b/src/__tests__/diff.test.ts
@@ -134,6 +134,7 @@ function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
     repoRoot: "/tmp/repo",
     diffelensRoot: "/tmp/diffelens",
     configPath: ".ai-review.yaml",
+    configExplicit: false,
     stateDir: ".ai-review-state",
     diffTarget: "all",
     cliBase: undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,12 +81,12 @@ interface RawConfig {
   filters: { exclude_patterns: string[] };
 }
 
+export const LOCAL_CONFIG_FILENAME = ".ai-review.local.yaml";
+
 const BUILTIN_LENSES = new Set(["readability", "architectural", "bug_risk"]);
 
-export async function loadConfig(configPath: string): Promise<ReviewConfig> {
-  const content = await readFile(configPath, "utf-8");
-  const raw = parseYaml(content) as RawConfig;
-
+/** Normalize raw config into the final ReviewConfig */
+function normalizeRawConfig(raw: RawConfig): ReviewConfig {
   const lenses: LensConfig[] = [];
 
   for (const [name, lens] of Object.entries(raw.lenses)) {
@@ -133,6 +133,91 @@ export async function loadConfig(configPath: string): Promise<ReviewConfig> {
     convergence: normalizeConvergence(raw.convergence),
     filters: raw.filters ?? { exclude_patterns: [] },
   };
+}
+
+export async function loadConfig(configPath: string): Promise<ReviewConfig> {
+  const content = await readFile(configPath, "utf-8");
+  const raw = parseYaml(content) as RawConfig;
+  return normalizeRawConfig(raw);
+}
+
+/**
+ * Deep merge a local overlay config over a base config.
+ * - global: field-level merge
+ * - lenses: per-lens field-level merge (new lenses are added)
+ * - convergence: field-level merge
+ * - filters.exclude_patterns: array replacement (not appended)
+ */
+export function deepMergeRawConfig(base: RawConfig, overlay: Record<string, unknown>): RawConfig {
+  const merged = { ...base };
+
+  // global: shallow merge
+  if (overlay.global && typeof overlay.global === "object") {
+    merged.global = { ...base.global, ...(overlay.global as Partial<RawConfig["global"]>) };
+  }
+
+  // lenses: per-lens field-level merge
+  if (overlay.lenses && typeof overlay.lenses === "object") {
+    const overlayLenses = overlay.lenses as Record<string, Partial<RawLensConfig>>;
+    const mergedLenses = { ...base.lenses };
+    for (const [name, lensOverlay] of Object.entries(overlayLenses)) {
+      if (name in mergedLenses) {
+        mergedLenses[name] = { ...mergedLenses[name], ...lensOverlay };
+      } else {
+        mergedLenses[name] = lensOverlay as RawLensConfig;
+      }
+    }
+    merged.lenses = mergedLenses;
+  }
+
+  // convergence: field-level merge
+  if (overlay.convergence && typeof overlay.convergence === "object") {
+    merged.convergence = {
+      ...base.convergence,
+      ...(overlay.convergence as Partial<RawConvergenceConfig>),
+    };
+  }
+
+  // filters: replace exclude_patterns array
+  if (overlay.filters && typeof overlay.filters === "object") {
+    const overlayFilters = overlay.filters as Partial<RawConfig["filters"]>;
+    if (overlayFilters.exclude_patterns) {
+      merged.filters = { ...base.filters, exclude_patterns: overlayFilters.exclude_patterns };
+    }
+  }
+
+  // version: overlay wins if present
+  if (overlay.version && typeof overlay.version === "string") {
+    merged.version = overlay.version;
+  }
+
+  return merged;
+}
+
+/**
+ * Load config with local overlay support.
+ * If localPath exists, deep-merges it over the base config before normalization.
+ */
+export async function loadConfigWithLocalOverlay(
+  basePath: string,
+  localPath: string
+): Promise<{ config: ReviewConfig; localOverlayApplied: boolean }> {
+  const baseContent = await readFile(basePath, "utf-8");
+  const baseRaw = parseYaml(baseContent) as RawConfig;
+
+  if (!existsSync(localPath)) {
+    return { config: normalizeRawConfig(baseRaw), localOverlayApplied: false };
+  }
+
+  const localContent = await readFile(localPath, "utf-8");
+  const localRaw = parseYaml(localContent) as Record<string, unknown>;
+
+  if (!localRaw || typeof localRaw !== "object") {
+    return { config: normalizeRawConfig(baseRaw), localOverlayApplied: false };
+  }
+
+  const merged = deepMergeRawConfig(baseRaw, localRaw);
+  return { config: normalizeRawConfig(merged), localOverlayApplied: true };
 }
 
 function resolvePromptConfig(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { join } from "path";
-import { loadConfig, loadConfigWithFallback } from "./config.js";
+import { existsSync } from "fs";
+import { loadConfig, loadConfigWithFallback, loadConfigWithLocalOverlay, LOCAL_CONFIG_FILENAME } from "./config.js";
 import { runLens, type LensRunResult } from "./lens-runner.js";
 import {
   loadOrCreateState,
@@ -48,11 +49,25 @@ export async function main(options?: RunOptions) {
   console.log("CLI availability:", availability);
 
   // 2. Load config (with fallback to diffelens default for local mode)
-  const fallbackConfigPath = join(opts.diffelensRoot, ".ai-review.yaml");
-  const config =
-    opts.mode === "local"
-      ? await loadConfigWithFallback(opts.configPath, fallbackConfigPath)
-      : await loadConfig(opts.configPath);
+  let config;
+  if (opts.mode === "local" && !opts.configExplicit) {
+    // Local mode without explicit --config: resolve base config (with fallback) + local overlay
+    const fallbackConfigPath = join(opts.diffelensRoot, ".ai-review.yaml");
+    const basePath = existsSync(opts.configPath) ? opts.configPath : fallbackConfigPath;
+    const localPath = join(opts.repoRoot, LOCAL_CONFIG_FILENAME);
+    const result = await loadConfigWithLocalOverlay(basePath, localPath);
+    config = result.config;
+    if (result.localOverlayApplied) {
+      console.log(`Config: loaded ${LOCAL_CONFIG_FILENAME} overlay`);
+    }
+  } else if (opts.mode === "local") {
+    // Local mode with explicit --config: use that file only, no overlay
+    const fallbackConfigPath = join(opts.diffelensRoot, ".ai-review.yaml");
+    config = await loadConfigWithFallback(opts.configPath, fallbackConfigPath);
+  } else {
+    // GitHub mode: use config as-is
+    config = await loadConfig(opts.configPath);
+  }
 
   console.log(
     `Config: ${config.lenses.length} lenses, max_rounds=${config.global.max_rounds}\n`

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,6 +15,7 @@ export interface RunOptions {
   repoRoot: string;
   diffelensRoot: string;
   configPath: string;
+  configExplicit: boolean;
   stateDir: string;
   diffTarget: DiffTarget;
   cliBase: string | undefined;
@@ -33,7 +34,9 @@ export function resolveOptions(): RunOptions {
   const explicitDiffTarget = parseArg(args, "--diff-target");
   const diffTarget = (explicitDiffTarget ?? "all") as DiffTarget;
   const stateDir = parseArg(args, "--state-dir") ?? defaultStateDir(mode);
-  const configPath = parseArg(args, "--config") ?? (process.env.CONFIG_PATH ?? ".ai-review.yaml");
+  const explicitConfig = parseArg(args, "--config") ?? process.env.CONFIG_PATH;
+  const configPath = explicitConfig ?? ".ai-review.yaml";
+  const configExplicit = explicitConfig !== undefined;
 
   const cliBase = parseArg(args, "--base");
   const cliHead = parseArg(args, "--head");
@@ -63,6 +66,7 @@ export function resolveOptions(): RunOptions {
       repoRoot,
       diffelensRoot,
       configPath,
+      configExplicit,
       stateDir,
       diffTarget,
       cliBase,
@@ -78,6 +82,7 @@ export function resolveOptions(): RunOptions {
     repoRoot,
     diffelensRoot,
     configPath,
+    configExplicit,
     stateDir,
     diffTarget,
     cliBase,


### PR DESCRIPTION
## Summary

- Add `.ai-review.local.yaml` auto-detection in local mode for environment-specific CLI/model configs
- Deep-merges local overlay over base config (field-level, not full replacement)
- `--config` explicit flag skips overlay entirely
- GitHub mode never applies overlay

## Design

```
--config explicit  → that file only (no overlay)
GitHub mode        → .ai-review.yaml only
Local mode         → .ai-review.yaml + .ai-review.local.yaml (deep merge)
```

### Merge rules

| Field | Strategy |
|-------|----------|
| `global.*` | Field-level overwrite |
| `lenses[name].*` | Per-lens field-level overwrite |
| `convergence.*` | Field-level overwrite |
| `filters.exclude_patterns` | Array replacement |

### Example `.ai-review.local.yaml`

```yaml
global:
  default_cli: "claude"
lenses:
  readability:
    cli: "claude"
    model: "claude-opus-4-6"
```

## Test plan

- [x] `npm test` — all 158 tests pass (12 new)
- [ ] Local mode with `.ai-review.local.yaml` → overlay applied
- [ ] Local mode without `.ai-review.local.yaml` → base config only
- [ ] `--config path` → overlay skipped

Closes #6