### PR TITLE
feat: add base_url support for API proxy and GHES compatibility

### DIFF
--- a/.diffelens.yaml
+++ b/.diffelens.yaml
@@ -8,6 +8,7 @@ global:
   language: "en"
   default_cli: "gemini"    # "claude", "codex", or "gemini"
   timeout_ms: 120000       # 2 minutes
+  # base_url: "https://proxy.example.com"  # API proxy for all lenses
 
 lenses:
   readability:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Multi-lens AI PR review orchestrator. Uses Claude Code CLI / Codex CLI as the ex
 - Config path: `--config` arg → `CONFIG_PATH` env var → `.diffelens.yaml` (cwd)
 - Local mode fallback: diffelens bundled `.diffelens.yaml` if repo has none
 - **Local overlay**: `.diffelens.local.yaml` is auto-detected in local mode and deep-merged over the base config. Only specified fields are overridden. Skipped when `--config` is explicitly provided. Use this to run different CLI/model settings locally (e.g., Claude Opus) vs CI (e.g., Gemini Flash)
+- **API proxy**: `global.base_url` or per-lens `base_url` sets CLI-specific env vars (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_API_BASE_URL`)
 - Convergence: `round_severities` array (N rounds) or legacy `round_N_severities` (auto-normalized)
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Multi-lens AI PR review orchestrator using LLM CLI tools such as Claude Code / C
 - **State Management**: Findings tracked across rounds — comment-embedded (GitHub) or file-based (local)
 - **Convergence Control**: Round limit + progressive severity filtering prevents endless review loops
 - **CLI Abstraction**: Claude Code / Codex / Gemini can be swapped via adapter pattern
+- **Custom API Endpoints**: Proxy / base URL support per-lens or global for enterprise API gateways
 
 ## Quick Start
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -136,6 +136,32 @@ env:
 
 See [Local Mode Guide — Configuration](./local-mode.md#configuration) for full config reference.
 
+## Proxy / Custom API Endpoints
+
+To route LLM API calls through a proxy, set `base_url` in `.diffelens.yaml`:
+
+```yaml
+global:
+  base_url: "https://genai-gateway.corp.example.com/v1"
+```
+
+Alternatively, set the CLI-specific env var directly in the workflow step:
+
+```yaml
+      - name: Run AI Review
+        run: npx tsx src/main.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_BASE_URL: "https://genai-gateway.corp.example.com/v1"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+```
+
+Config-based `base_url` takes precedence over ambient env vars (e.g., `ANTHROPIC_BASE_URL` set in the workflow). See [Local Mode — CLI-to-env-var mapping](./local-mode.md#cli-to-env-var-mapping) for the full mapping table.
+
 ## State Management
 
 diffelens uses **comment-embedded state** for cross-round persistence in GitHub mode. Review state is encoded as a hidden HTML marker (`<!-- diffelens-state: {base64} -->`) at the end of the summary comment. No artifacts or external storage are needed.

--- a/docs/local-mode.md
+++ b/docs/local-mode.md
@@ -123,6 +123,7 @@ global:
   language: "en"
   default_cli: "claude"
   timeout_ms: 120000
+  # base_url: "https://proxy.example.com"
 
 lenses:
   readability:
@@ -166,6 +167,7 @@ global:
   max_rounds: 2
   default_cli: "gemini"
   timeout_ms: 120000
+  # base_url: "https://proxy.example.com"
 
 lenses:
   readability:
@@ -197,6 +199,8 @@ lenses:
 | `lenses.<name>.isolation` | `tempdir` (diff only) or `repo` (full repository access) |
 | `lenses.<name>.tool_policy` | `none`, `read_only`, or `{ type: "explicit", tools: [...] }` |
 | `lenses.<name>.severity_cap` | Maximum severity a lens can produce (`blocker`, `warning`, `nitpick`) |
+| `global.base_url` | API proxy base URL for all lenses |
+| `lenses.<name>.base_url` | Per-lens API proxy base URL (overrides global) |
 | `filters.exclude_patterns` | Glob patterns for files to exclude from the diff |
 
 ## Custom Prompts
@@ -220,6 +224,52 @@ lenses:
 ```
 
 Custom lenses (names other than `readability`, `architectural`, `bug_risk`) always require `prompt_file`.
+
+## Custom API Endpoints / Proxy
+
+Use `base_url` to route LLM API calls through a proxy (e.g., corporate API gateway).
+
+### Global proxy
+
+```yaml
+global:
+  default_cli: "claude"
+  base_url: "https://ai-proxy.corp.example.com"
+```
+
+### Per-lens override
+
+```yaml
+lenses:
+  readability:
+    cli: "claude"
+    base_url: "https://claude-proxy.example.com"
+  bug_risk:
+    cli: "codex"
+    base_url: "https://openai-proxy.example.com"
+```
+
+### Local overlay for proxy
+
+```yaml
+# .diffelens.local.yaml
+global:
+  base_url: "http://localhost:8080"
+```
+
+### Precedence
+
+```
+per-lens base_url > global base_url > ambient env var > CLI default
+```
+
+### CLI-to-env-var mapping
+
+| CLI | Env var set by diffelens |
+|-----|--------------------------|
+| Claude Code | `ANTHROPIC_BASE_URL` |
+| Codex | `OPENAI_BASE_URL` |
+| Gemini | `GEMINI_API_BASE_URL` |
 
 ## Convergence
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -302,6 +302,78 @@ describe("loadConfig convergence normalization", () => {
 });
 
 // ============================================================
+// base_url validation and propagation
+// ============================================================
+
+describe("loadConfig base_url", () => {
+  it("global base_url propagates to all lenses", async () => {
+    const path = await writeYamlConfig(BASE_YAML(`
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+`, `  round_severities:
+    - ["blocker", "warning", "nitpick"]
+  approve_condition: "zero_blockers"
+`).replace(
+      'timeout_ms: 120000',
+      'timeout_ms: 120000\n  base_url: "https://proxy.example.com"'
+    ));
+
+    const config = await loadConfig(path);
+    const lens = config.lenses.find((l) => l.name === "readability")!;
+    expect(lens.baseUrl).toBe("https://proxy.example.com");
+  });
+
+  it("per-lens base_url overrides global", async () => {
+    const path = await writeYamlConfig(BASE_YAML(`
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+    base_url: "https://lens-proxy.example.com"
+`, `  round_severities:
+    - ["blocker", "warning", "nitpick"]
+  approve_condition: "zero_blockers"
+`).replace(
+      'timeout_ms: 120000',
+      'timeout_ms: 120000\n  base_url: "https://global-proxy.example.com"'
+    ));
+
+    const config = await loadConfig(path);
+    const lens = config.lenses.find((l) => l.name === "readability")!;
+    expect(lens.baseUrl).toBe("https://lens-proxy.example.com");
+  });
+
+  it("no base_url yields undefined", async () => {
+    const path = await writeYamlConfig(BASE_YAML(MINIMAL_LENS));
+    const config = await loadConfig(path);
+    const lens = config.lenses.find((l) => l.name === "readability")!;
+    expect(lens.baseUrl).toBeUndefined();
+  });
+
+  it("invalid global base_url throws descriptive error", async () => {
+    const path = await writeYamlConfig(BASE_YAML(MINIMAL_LENS).replace(
+      'timeout_ms: 120000',
+      'timeout_ms: 120000\n  base_url: "not-a-url"'
+    ));
+
+    await expect(loadConfig(path)).rejects.toThrow('global: invalid base_url: "not-a-url"');
+  });
+
+  it("non-http(s) protocol throws", async () => {
+    const path = await writeYamlConfig(BASE_YAML(MINIMAL_LENS).replace(
+      'timeout_ms: 120000',
+      'timeout_ms: 120000\n  base_url: "ftp://proxy.example.com"'
+    ));
+
+    await expect(loadConfig(path)).rejects.toThrow("global: base_url must use http:// or https://");
+  });
+});
+
+// ============================================================
 // deepMergeRawConfig
 // ============================================================
 
@@ -419,6 +491,24 @@ describe("deepMergeRawConfig", () => {
     const merged = deepMergeRawConfig(base, overlay);
 
     expect(merged.lenses.readability.enabled).toBe(false);
+  });
+
+  it("merges global base_url from overlay", () => {
+    const base = makeRawConfig();
+    const overlay = { global: { base_url: "https://proxy.example.com" } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.global.base_url).toBe("https://proxy.example.com");
+    expect(merged.global.default_cli).toBe("gemini");
+  });
+
+  it("merges per-lens base_url from overlay", () => {
+    const base = makeRawConfig();
+    const overlay = { lenses: { readability: { base_url: "https://lens-proxy.example.com" } } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.lenses.readability.base_url).toBe("https://lens-proxy.example.com");
+    expect(merged.lenses.readability.model).toBe("gemini-2.5-flash");
   });
 
   it("does not mutate the base config", () => {

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -31,7 +31,11 @@ export class ClaudeCodeAdapter implements CLIAdapter {
     return new Promise((resolve) => {
       const child = spawn("claude", args, {
         cwd: request.cwd,
-        env: { ...process.env, CLAUDECODE: "" },
+        env: {
+          ...process.env,
+          CLAUDECODE: "",
+          ...(request.baseUrl ? { ANTHROPIC_BASE_URL: request.baseUrl } : {}),
+        },
         stdio: ["pipe", "pipe", "pipe"],
       });
 

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -32,7 +32,10 @@ export class CodexAdapter implements CLIAdapter {
     return new Promise((resolve) => {
       const child = spawn("codex", args, {
         cwd: request.cwd,
-        env: { ...process.env },
+        env: {
+          ...process.env,
+          ...(request.baseUrl ? { OPENAI_BASE_URL: request.baseUrl } : {}),
+        },
         stdio: ["pipe", "pipe", "pipe"],
       });
 

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -33,6 +33,7 @@ export class GeminiAdapter implements CLIAdapter {
         env: {
           ...process.env,
           GEMINI_SYSTEM_MD: request.systemPromptPath,
+          ...(request.baseUrl ? { GEMINI_API_BASE_URL: request.baseUrl } : {}),
         },
         stdio: ["pipe", "pipe", "pipe"],
       });

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -28,6 +28,9 @@ export interface CLIRequest {
 
   /** Timeout (ms) */
   timeoutMs: number;
+
+  /** Optional: API proxy base URL */
+  baseUrl?: string;
 }
 
 export type ToolPolicy =

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export interface GlobalConfig {
   language: string;
   default_cli: CLIName;
   timeout_ms: number;
+  base_url?: string;
 }
 
 export interface LensConfig {
@@ -26,6 +27,7 @@ export interface LensConfig {
   timeoutMs: number;
   isolation: "tempdir" | "repo";
   severityCap: "blocker" | "warning" | "nitpick";
+  baseUrl?: string;
 }
 
 export interface ConvergenceConfig {
@@ -66,6 +68,7 @@ interface RawLensConfig {
   severity_cap?: "blocker" | "warning" | "nitpick";
   prompt_file?: string;
   prompt_append_file?: string;
+  base_url?: string;
 }
 
 interface RawConfig {
@@ -75,6 +78,7 @@ interface RawConfig {
     language: string;
     default_cli: CLIName;
     timeout_ms: number;
+    base_url?: string;
   };
   lenses: Record<string, RawLensConfig>;
   convergence: RawConvergenceConfig;
@@ -85,9 +89,28 @@ export const LOCAL_CONFIG_FILENAME = ".diffelens.local.yaml";
 
 const BUILTIN_LENSES = new Set(["readability", "architectural", "bug_risk"]);
 
+/** Validate that a base_url is a valid http(s) URL */
+function validateBaseUrl(url: string, context: string): void {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`${context}: base_url must use http:// or https://`);
+    }
+  } catch (e) {
+    if (e instanceof TypeError) {
+      throw new Error(`${context}: invalid base_url: "${url}"`);
+    }
+    throw e;
+  }
+}
+
 /** Normalize raw config into the final ReviewConfig */
 function normalizeRawConfig(raw: RawConfig): ReviewConfig {
   const lenses: LensConfig[] = [];
+
+  if (raw.global.base_url) {
+    validateBaseUrl(raw.global.base_url, "global");
+  }
 
   for (const [name, lens] of Object.entries(raw.lenses)) {
     if (!lens.enabled) continue;
@@ -104,6 +127,10 @@ function normalizeRawConfig(raw: RawConfig): ReviewConfig {
       throw new Error(
         `Custom lens "${name}" requires a prompt_file`
       );
+    }
+
+    if (lens.base_url) {
+      validateBaseUrl(lens.base_url, `lens "${name}"`);
     }
 
     const { promptFile, promptSource, promptAppendFile } = resolvePromptConfig(
@@ -124,6 +151,7 @@ function normalizeRawConfig(raw: RawConfig): ReviewConfig {
       timeoutMs: lens.timeout_ms ?? raw.global.timeout_ms,
       isolation: lens.isolation,
       severityCap: lens.severity_cap ?? "blocker",
+      baseUrl: lens.base_url ?? raw.global.base_url,
     });
   }
 

--- a/src/lens-runner.ts
+++ b/src/lens-runner.ts
@@ -53,6 +53,7 @@ export async function runLens(
       toolPolicy: config.toolPolicy,
       model: config.model,
       timeoutMs: config.timeoutMs,
+      baseUrl: config.baseUrl,
     };
 
     console.log(`    [${config.name}] Executing ${adapter.name} (${config.model})...`);

--- a/src/output/github-client.ts
+++ b/src/output/github-client.ts
@@ -14,7 +14,10 @@ export function getOctokit(): Octokit {
   if (!octokitInstance) {
     const token = process.env.GITHUB_TOKEN;
     if (!token) throw new Error("GITHUB_TOKEN is not set");
-    octokitInstance = new Octokit({ auth: token });
+    octokitInstance = new Octokit({
+      auth: token,
+      baseUrl: process.env.GITHUB_API_URL || "https://api.github.com",
+    });
   }
   return octokitInstance;
 }


### PR DESCRIPTION
## Summary

- Add `base_url` config option (global and per-lens) to route LLM API calls through corporate proxies / API gateways
- Each CLI adapter maps `baseUrl` to its native env var (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GEMINI_API_BASE_URL`), placed after `process.env` so config takes precedence over ambient values
- Add GHES (GitHub Enterprise Server) support by reading `GITHUB_API_URL` env var in Octokit constructor
- URL validation ensures only `http://` or `https://` protocols are accepted
- Precedence: per-lens `base_url` > global `base_url` > ambient env var > CLI default

## Test plan

- [x] `npx vitest run` — all 166 tests pass (7 new `base_url` tests)
- [ ] Manual: set `base_url` in `.diffelens.local.yaml` pointing to a mock server, verify env var appears in child process
- [ ] Verify no `base_url` config works identically (backward compatible)
- [ ] GHES: verify `GITHUB_API_URL` is respected by Octokit constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)