### PR TITLE
feat: add recurrence detection to suppress oscillating findings

### DIFF
--- a/src/__tests__/recurrence.test.ts
+++ b/src/__tests__/recurrence.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from "vitest";
+import { detectAndSuppressRecurrences } from "../recurrence.js";
+import type { ReviewState, StateFinding } from "../state/review-state.js";
+import type { Finding } from "../adapters/types.js";
+
+function makeState(overrides: Partial<ReviewState> = {}): ReviewState {
+  return {
+    schema_version: "1.0",
+    pr_number: 1,
+    repository: "test/repo",
+    current_round: 2,
+    max_rounds: 3,
+    base_sha: "aaa",
+    head_sha: "bbb",
+    findings: [],
+    round_history: [],
+    decisions: [],
+    ...overrides,
+  };
+}
+
+function makeStateFinding(
+  overrides: Partial<StateFinding> = {}
+): StateFinding {
+  return {
+    id: "r-001",
+    lens: "readability",
+    status: "open",
+    first_raised_round: 1,
+    last_evaluated_round: 1,
+    resolution_note: null,
+    file: "src/app.ts",
+    line_start: 10,
+    line_end: 15,
+    severity: "warning",
+    category: "naming",
+    summary: "bad name",
+    suggestion: "rename",
+    ...overrides,
+  };
+}
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    file: "src/app.ts",
+    line_start: 10,
+    line_end: 15,
+    severity: "warning",
+    category: "naming",
+    summary: "bad name",
+    suggestion: "rename",
+    lens: "readability",
+    ...overrides,
+  };
+}
+
+describe("detectAndSuppressRecurrences", () => {
+  it("suppresses a finding that was open then addressed and now reappears", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          last_evaluated_round: 2,
+          resolution_note: "Resolved in round 2",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 10,
+        line_end: 15,
+        category: "naming",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(1);
+    expect(result.directives[0].originalFindingId).toBe("r-001");
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("does not suppress a first-time finding (no prior history)", () => {
+    const state = makeState({
+      current_round: 1,
+      findings: [],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({ file: "src/app.ts", category: "naming" }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("does not suppress when category differs", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          category: "naming",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 10,
+        line_end: 15,
+        category: "error_handling",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("does not suppress when file differs", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          file: "src/app.ts",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({ file: "src/other.ts", category: "naming" }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("does not suppress findings that are still open (not addressed)", () => {
+    const state = makeState({
+      current_round: 2,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "open",
+          first_raised_round: 1,
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 10,
+        line_end: 15,
+        category: "naming",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("handles round 1 with no history gracefully", () => {
+    const state = makeState({
+      current_round: 1,
+      findings: [],
+    });
+
+    const result = detectAndSuppressRecurrences(state, []);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("suppresses multiple recurrences simultaneously", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          file: "src/app.ts",
+          line_start: 10,
+          line_end: 15,
+          category: "naming",
+        }),
+        makeStateFinding({
+          id: "b-002",
+          status: "addressed",
+          first_raised_round: 1,
+          file: "src/db.ts",
+          line_start: 20,
+          line_end: 25,
+          category: "sql_injection",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 10,
+        line_end: 15,
+        category: "naming",
+      }),
+      makeFinding({
+        file: "src/db.ts",
+        line_start: 20,
+        line_end: 25,
+        category: "sql_injection",
+      }),
+      makeFinding({
+        file: "src/new.ts",
+        line_start: 1,
+        line_end: 5,
+        category: "complexity",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(2);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].file).toBe("src/new.ts");
+  });
+
+  it("detects recurrence when lines overlap but are shifted", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          file: "src/app.ts",
+          line_start: 10,
+          line_end: 20,
+          category: "naming",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 15,
+        line_end: 25,
+        category: "naming",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(1);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("does not suppress when lines do not overlap", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+          file: "src/app.ts",
+          line_start: 10,
+          line_end: 15,
+          category: "naming",
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({
+        file: "src/app.ts",
+        line_start: 50,
+        line_end: 60,
+        category: "naming",
+      }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it("does not mutate input arrays", () => {
+    const state = makeState({
+      current_round: 3,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 1,
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({ file: "src/app.ts", category: "naming" }),
+    ];
+    const originalLength = newFindings.length;
+
+    detectAndSuppressRecurrences(state, newFindings);
+
+    expect(newFindings).toHaveLength(originalLength);
+  });
+
+  it("does not suppress findings addressed in the current round", () => {
+    const state = makeState({
+      current_round: 2,
+      findings: [
+        makeStateFinding({
+          id: "r-001",
+          status: "addressed",
+          first_raised_round: 2,
+          last_evaluated_round: 2,
+        }),
+      ],
+    });
+
+    const newFindings: Finding[] = [
+      makeFinding({ file: "src/app.ts", category: "naming" }),
+    ];
+
+    const result = detectAndSuppressRecurrences(state, newFindings);
+
+    expect(result.directives).toHaveLength(0);
+    expect(result.findings).toHaveLength(1);
+  });
+});

--- a/src/__tests__/recurrence.test.ts
+++ b/src/__tests__/recurrence.test.ts
@@ -82,6 +82,7 @@ describe("detectAndSuppressRecurrences", () => {
 
     expect(result.directives).toHaveLength(1);
     expect(result.directives[0].originalFindingId).toBe("r-001");
+    expect(result.directives[0].suppressedSummary).toBe("bad name");
     expect(result.findings).toHaveLength(0);
   });
 

--- a/src/deduplicator.ts
+++ b/src/deduplicator.ts
@@ -1,29 +1,16 @@
 import type { Finding } from "./adapters/types.js";
 import { SEVERITY_RANK } from "./severity.js";
-import { linesOverlap } from "./state/review-state.js";
+import { findingsMatch } from "./state/review-state.js";
 
 // ============================================================
 // Merge results from multiple lenses and deduplicate findings
 // ============================================================
 
-/**
- * Duplicate detection: same file, overlapping line range, and same category.
- * Findings from different lenses with different categories are not duplicates.
- * e.g. "naming" (readability) vs "layer_violation" (architectural) -> separate findings
- */
-function isDuplicate(a: Finding, b: Finding): boolean {
-  if (a.file !== b.file) return false;
-  if (!linesOverlap(a.line_start, a.line_end, b.line_start, b.line_end))
-    return false;
-  if (a.category !== b.category) return false;
-  return true;
-}
-
 export function deduplicateFindings(findings: Finding[]): Finding[] {
   const merged: Finding[] = [];
 
   for (const finding of findings) {
-    const dupIndex = merged.findIndex((m) => isDuplicate(m, finding));
+    const dupIndex = merged.findIndex((m) => findingsMatch(m, finding));
 
     if (dupIndex >= 0) {
       // Duplicate: keep the higher severity

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   advanceRoundIfNeeded,
   updateState,
   saveState,
+  applyRecurrenceSuppressions,
 } from "./state/review-state.js";
 import { deduplicateFindings } from "./deduplicator.js";
 import { detectAndSuppressRecurrences } from "./recurrence.js";
@@ -256,19 +257,8 @@ export async function main(options?: RunOptions) {
   }
 
   // 10. Update state
-  const newState = updateState(state, [...recurrence.findings], headSha);
-  const finalState: typeof newState = {
-    ...newState,
-    recurrence_suppressions: [
-      ...(state.recurrence_suppressions ?? []),
-      ...recurrence.directives.map((d) => ({
-        originalFindingId: d.originalFindingId,
-        suppressedAtRound: state.current_round,
-        file: d.file,
-        category: d.category,
-      })),
-    ],
-  };
+  const newState = updateState(state, recurrence.findings, headSha);
+  const finalState = applyRecurrenceSuppressions(newState, recurrence.directives);
   const openCount = finalState.findings.filter(
     (f) => f.status === "open"
   ).length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
   saveState,
 } from "./state/review-state.js";
 import { deduplicateFindings } from "./deduplicator.js";
+import { detectAndSuppressRecurrences } from "./recurrence.js";
 import {
   checkConvergence,
   filterBySeverityForRound,
@@ -245,18 +246,39 @@ export async function main(options?: RunOptions) {
   const deduplicated = deduplicateFindings(filtered);
   console.log(`  -> ${deduplicated.length} after deduplication`);
 
+  // 9a. Recurrence detection
+  const recurrence = detectAndSuppressRecurrences(state, deduplicated);
+  if (recurrence.directives.length > 0) {
+    console.log(
+      `  -> ${recurrence.findings.length} after recurrence suppression ` +
+      `(${recurrence.directives.length} suppressed)`
+    );
+  }
+
   // 10. Update state
-  const newState = updateState(state, deduplicated, headSha);
-  const openCount = newState.findings.filter(
+  const newState = updateState(state, [...recurrence.findings], headSha);
+  const finalState: typeof newState = {
+    ...newState,
+    recurrence_suppressions: [
+      ...(state.recurrence_suppressions ?? []),
+      ...recurrence.directives.map((d) => ({
+        originalFindingId: d.originalFindingId,
+        suppressedAtRound: state.current_round,
+        file: d.file,
+        category: d.category,
+      })),
+    ],
+  };
+  const openCount = finalState.findings.filter(
     (f) => f.status === "open"
   ).length;
-  const resolvedCount = newState.findings.filter(
+  const resolvedCount = finalState.findings.filter(
     (f) => f.status === "addressed"
   ).length;
   console.log(`  Open: ${openCount}, Resolved: ${resolvedCount}\n`);
 
   // 11. Convergence decision
-  const decision = checkConvergence(newState, config.convergence);
+  const decision = checkConvergence(finalState, config.convergence);
   console.log(`Decision: ${decision}`);
 
   // 12. Build review scope for summary
@@ -275,18 +297,18 @@ export async function main(options?: RunOptions) {
 
   // 13. Output: GitHub API for github mode with token, stdout otherwise
   if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
-    await upsertSummaryComment(opts.prNumber, newState, decision, scope);
+    await upsertSummaryComment(opts.prNumber, finalState, decision, scope);
   } else {
     const { renderSummary } = await import(
       "./output/summary-renderer.js"
     );
     console.log("\n--- Summary ---");
-    console.log(renderSummary(newState, decision, opts.mode, scope));
+    console.log(renderSummary(finalState, decision, opts.mode, scope));
   }
 
   // 14. Save state (local mode only; GitHub mode persists via comment)
   if (opts.mode === "local") {
-    await saveState(opts.stateDir, newState);
+    await saveState(opts.stateDir, finalState);
   }
 
   console.log("\nAI Review — Done.");

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -44,6 +44,8 @@ export function renderSummary(
         ? "🚨 ESCALATED (human review required)"
         : "🔄 CHANGES REQUESTED";
 
+  const suppressionCount = state.recurrence_suppressions?.length ?? 0;
+
   const lines: string[] = [
     MARKER,
     `## 🤖 AI Review — Round ${state.current_round}/${state.max_rounds}`,
@@ -58,6 +60,13 @@ export function renderSummary(
     `| ✅ Resolved | ${resolved.length} |`,
     "",
   ];
+
+  if (suppressionCount > 0) {
+    lines.push(
+      `> **Note:** ${suppressionCount} finding(s) suppressed — recurrence detected (same location was fixed then re-raised)`,
+      "",
+    );
+  }
 
   // Review Scope (collapsible)
   if (scope) {

--- a/src/recurrence.ts
+++ b/src/recurrence.ts
@@ -1,10 +1,6 @@
 import type { ReviewState, StateFinding } from "./state/review-state.js";
 import type { Finding } from "./adapters/types.js";
-import { linesOverlap } from "./state/review-state.js";
-
-// ============================================================
-// Recurrence Detection: suppress oscillating findings
-// ============================================================
+import { findingsMatch } from "./state/review-state.js";
 
 export interface RecurrenceDirective {
   /** Index of the suppressed finding in the original newFindings array */
@@ -19,7 +15,7 @@ export interface RecurrenceDirective {
 export interface RecurrenceResult {
   directives: readonly RecurrenceDirective[];
   /** Findings after suppression */
-  findings: readonly Finding[];
+  findings: Finding[];
 }
 
 /**
@@ -41,27 +37,27 @@ export function detectAndSuppressRecurrences(
   );
 
   if (addressedFromPriorRounds.length === 0) {
-    return { directives: [], findings: newFindings };
+    return { directives: [], findings: [...newFindings] };
   }
 
   const directives: RecurrenceDirective[] = [];
   const suppressedIndices = new Set<number>();
 
   for (let i = 0; i < newFindings.length; i++) {
-    const nf = newFindings[i];
-    const match = addressedFromPriorRounds.find((af) =>
-      isMatchingFinding(nf, af)
+    const candidate = newFindings[i];
+    const priorMatch = addressedFromPriorRounds.find((addressedFinding) =>
+      findingsMatch(candidate, addressedFinding)
     );
 
-    if (match) {
+    if (priorMatch) {
       directives.push({
         targetIndex: i,
-        originalFindingId: match.id,
-        file: nf.file,
-        category: nf.category,
+        originalFindingId: priorMatch.id,
+        file: candidate.file,
+        category: candidate.category,
         reason:
-          `Finding matches previously addressed ${match.id} ` +
-          `(raised round ${match.first_raised_round}, addressed, now recurring)`,
+          `Finding matches previously addressed ${priorMatch.id} ` +
+          `(raised round ${priorMatch.first_raised_round}, addressed, now recurring)`,
       });
       suppressedIndices.add(i);
     }
@@ -70,12 +66,4 @@ export function detectAndSuppressRecurrences(
   const findings = newFindings.filter((_, i) => !suppressedIndices.has(i));
 
   return { directives, findings };
-}
-
-function isMatchingFinding(a: Finding, b: StateFinding): boolean {
-  return (
-    a.file === b.file &&
-    a.category === b.category &&
-    linesOverlap(a.line_start, a.line_end, b.line_start, b.line_end)
-  );
 }

--- a/src/recurrence.ts
+++ b/src/recurrence.ts
@@ -1,0 +1,81 @@
+import type { ReviewState, StateFinding } from "./state/review-state.js";
+import type { Finding } from "./adapters/types.js";
+import { linesOverlap } from "./state/review-state.js";
+
+// ============================================================
+// Recurrence Detection: suppress oscillating findings
+// ============================================================
+
+export interface RecurrenceDirective {
+  /** Index of the suppressed finding in the original newFindings array */
+  targetIndex: number;
+  /** ID of the previously addressed finding that recurred */
+  originalFindingId: string;
+  file: string;
+  category: string;
+  reason: string;
+}
+
+export interface RecurrenceResult {
+  directives: readonly RecurrenceDirective[];
+  /** Findings after suppression */
+  findings: readonly Finding[];
+}
+
+/**
+ * Detect recurring findings and suppress them.
+ *
+ * A "recurrence" is when a finding was open, then addressed (developer fixed it),
+ * and now reappears at the same location with the same category.
+ * This indicates a pendulum effect — the LLM keeps flip-flopping.
+ *
+ * Pure function — no LLM, no side effects.
+ */
+export function detectAndSuppressRecurrences(
+  state: ReviewState,
+  newFindings: readonly Finding[]
+): RecurrenceResult {
+  const addressedFromPriorRounds = state.findings.filter(
+    (f): f is StateFinding =>
+      f.status === "addressed" && f.first_raised_round < state.current_round
+  );
+
+  if (addressedFromPriorRounds.length === 0) {
+    return { directives: [], findings: newFindings };
+  }
+
+  const directives: RecurrenceDirective[] = [];
+  const suppressedIndices = new Set<number>();
+
+  for (let i = 0; i < newFindings.length; i++) {
+    const nf = newFindings[i];
+    const match = addressedFromPriorRounds.find((af) =>
+      isMatchingFinding(nf, af)
+    );
+
+    if (match) {
+      directives.push({
+        targetIndex: i,
+        originalFindingId: match.id,
+        file: nf.file,
+        category: nf.category,
+        reason:
+          `Finding matches previously addressed ${match.id} ` +
+          `(raised round ${match.first_raised_round}, addressed, now recurring)`,
+      });
+      suppressedIndices.add(i);
+    }
+  }
+
+  const findings = newFindings.filter((_, i) => !suppressedIndices.has(i));
+
+  return { directives, findings };
+}
+
+function isMatchingFinding(a: Finding, b: StateFinding): boolean {
+  return (
+    a.file === b.file &&
+    a.category === b.category &&
+    linesOverlap(a.line_start, a.line_end, b.line_start, b.line_end)
+  );
+}

--- a/src/recurrence.ts
+++ b/src/recurrence.ts
@@ -1,4 +1,4 @@
-import type { ReviewState, StateFinding } from "./state/review-state.js";
+import type { ReviewState } from "./state/review-state.js";
 import type { Finding } from "./adapters/types.js";
 import { findingsMatch } from "./state/review-state.js";
 
@@ -10,6 +10,8 @@ export interface RecurrenceDirective {
   file: string;
   category: string;
   reason: string;
+  /** Summary of the suppressed finding for audit trail */
+  suppressedSummary: string;
 }
 
 export interface RecurrenceResult {
@@ -32,8 +34,7 @@ export function detectAndSuppressRecurrences(
   newFindings: readonly Finding[]
 ): RecurrenceResult {
   const addressedFromPriorRounds = state.findings.filter(
-    (f): f is StateFinding =>
-      f.status === "addressed" && f.first_raised_round < state.current_round
+    (f) => f.status === "addressed" && f.first_raised_round < state.current_round
   );
 
   if (addressedFromPriorRounds.length === 0) {
@@ -58,6 +59,7 @@ export function detectAndSuppressRecurrences(
         reason:
           `Finding matches previously addressed ${priorMatch.id} ` +
           `(raised round ${priorMatch.first_raised_round}, addressed, now recurring)`,
+        suppressedSummary: candidate.summary,
       });
       suppressedIndices.add(i);
     }

--- a/src/state/review-state.ts
+++ b/src/state/review-state.ts
@@ -29,7 +29,11 @@ export interface RecurrenceSuppression {
   suppressedAtRound: number;
   file: string;
   category: string;
+  suppressedSummary?: string;
 }
+
+/** Minimal shape for finding location matching */
+export type FindingLocation = Pick<Finding, "file" | "line_start" | "line_end" | "category">;
 
 export interface ReviewState {
   schema_version: string;
@@ -141,17 +145,7 @@ export function updateState(
   const updatedFindings = state.findings.map((existing) => {
     if (existing.status !== "open") return existing;
 
-    const stillExists = newFindings.some(
-      (nf) =>
-        nf.file === existing.file &&
-        nf.category === existing.category &&
-        linesOverlap(
-          nf.line_start,
-          nf.line_end,
-          existing.line_start,
-          existing.line_end
-        )
-    );
+    const stillExists = newFindings.some((nf) => findingsMatch(nf, existing));
 
     if (!stillExists) {
       resolved.push(existing.id);
@@ -173,16 +167,7 @@ export function updateState(
   const addedFindings: StateFinding[] = [];
   for (const nf of newFindings) {
     const existingMatch = updatedFindings.find(
-      (ef) =>
-        ef.status === "open" &&
-        ef.file === nf.file &&
-        ef.category === nf.category &&
-        linesOverlap(
-          nf.line_start,
-          nf.line_end,
-          ef.line_start,
-          ef.line_end
-        )
+      (ef) => ef.status === "open" && findingsMatch(nf, ef)
     );
 
     if (!existingMatch) {
@@ -234,10 +219,7 @@ export async function saveState(
 // ---- Helpers (exported for reuse and testing) ----
 
 /** Check if two findings refer to the same location: file + category + overlapping lines */
-export function findingsMatch(
-  a: { file: string; line_start: number; line_end: number; category: string },
-  b: { file: string; line_start: number; line_end: number; category: string }
-): boolean {
+export function findingsMatch(a: FindingLocation, b: FindingLocation): boolean {
   return (
     a.file === b.file &&
     a.category === b.category &&
@@ -259,27 +241,33 @@ export function generateFindingId(lens: string, index: number): string {
   return `${prefix}-${String(index + 1).padStart(3, "0")}`;
 }
 
-/** Merge recurrence suppression history into state (immutable) */
+/** Merge recurrence suppression history into state (immutable, deduped by originalFindingId) */
 export function applyRecurrenceSuppressions(
   state: ReviewState,
   directives: readonly {
     originalFindingId: string;
     file: string;
     category: string;
+    suppressedSummary?: string;
   }[]
 ): ReviewState {
   if (directives.length === 0) return state;
 
+  const existing = state.recurrence_suppressions ?? [];
+  const existingIds = new Set(existing.map((s) => s.originalFindingId));
+
+  const newSuppressions: RecurrenceSuppression[] = directives
+    .filter((d) => !existingIds.has(d.originalFindingId))
+    .map((d) => ({
+      originalFindingId: d.originalFindingId,
+      suppressedAtRound: state.current_round,
+      file: d.file,
+      category: d.category,
+      suppressedSummary: d.suppressedSummary,
+    }));
+
   return {
     ...state,
-    recurrence_suppressions: [
-      ...(state.recurrence_suppressions ?? []),
-      ...directives.map((d) => ({
-        originalFindingId: d.originalFindingId,
-        suppressedAtRound: state.current_round,
-        file: d.file,
-        category: d.category,
-      })),
-    ],
+    recurrence_suppressions: [...existing, ...newSuppressions],
   };
 }

--- a/src/state/review-state.ts
+++ b/src/state/review-state.ts
@@ -231,7 +231,19 @@ export async function saveState(
   console.log(`  State saved → ${filePath}`);
 }
 
-// ---- Helpers (exported for testing) ----
+// ---- Helpers (exported for reuse and testing) ----
+
+/** Check if two findings refer to the same location: file + category + overlapping lines */
+export function findingsMatch(
+  a: { file: string; line_start: number; line_end: number; category: string },
+  b: { file: string; line_start: number; line_end: number; category: string }
+): boolean {
+  return (
+    a.file === b.file &&
+    a.category === b.category &&
+    linesOverlap(a.line_start, a.line_end, b.line_start, b.line_end)
+  );
+}
 
 export function linesOverlap(
   aStart: number,
@@ -245,4 +257,29 @@ export function linesOverlap(
 export function generateFindingId(lens: string, index: number): string {
   const prefix = lens.charAt(0); // r, s, b
   return `${prefix}-${String(index + 1).padStart(3, "0")}`;
+}
+
+/** Merge recurrence suppression history into state (immutable) */
+export function applyRecurrenceSuppressions(
+  state: ReviewState,
+  directives: readonly {
+    originalFindingId: string;
+    file: string;
+    category: string;
+  }[]
+): ReviewState {
+  if (directives.length === 0) return state;
+
+  return {
+    ...state,
+    recurrence_suppressions: [
+      ...(state.recurrence_suppressions ?? []),
+      ...directives.map((d) => ({
+        originalFindingId: d.originalFindingId,
+        suppressedAtRound: state.current_round,
+        file: d.file,
+        category: d.category,
+      })),
+    ],
+  };
 }

--- a/src/state/review-state.ts
+++ b/src/state/review-state.ts
@@ -24,6 +24,13 @@ export interface RoundHistory {
   findings_resolved: string[];
 }
 
+export interface RecurrenceSuppression {
+  originalFindingId: string;
+  suppressedAtRound: number;
+  file: string;
+  category: string;
+}
+
 export interface ReviewState {
   schema_version: string;
   pr_number: number;
@@ -35,6 +42,7 @@ export interface ReviewState {
   findings: StateFinding[];
   round_history: RoundHistory[];
   decisions: string[];
+  recurrence_suppressions?: RecurrenceSuppression[];
 }
 
 function stateFilePath(stateDir: string, stateKey: string): string {


### PR DESCRIPTION
## Summary

- Add recurrence detection to suppress the "pendulum effect" where findings oscillate between open → addressed → re-open across rounds
- Insert `detectAndSuppressRecurrences()` into the pipeline between dedup and state update
- Add `RecurrenceSuppression` type to `ReviewState` as an optional field (backward-compatible)
- Display suppression count in the summary output

## Test plan

- [x] `npx vitest run src/__tests__/recurrence.test.ts` — 11 tests pass
- [x] `npx vitest run` — all 187 tests pass (no regressions)
- [ ] Run diffelens on this PR to verify normal operation with no prior recurrence state