### PR TITLE
feat: add skills system for dynamic review customization

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -687,14 +687,18 @@ describe("loadConfig skills", () => {
     expect(inject.mode).toBe("inject");
     expect(inject.promptFile).toBe("skills/react.md");
     expect(inject.triggers.filePatterns).toEqual(["**/*.tsx"]);
-    expect(inject.attachTo).toEqual(["bug_risk"]);
+    if (inject.mode === "inject") {
+      expect(inject.attachTo).toEqual(["bug_risk"]);
+    }
 
     const standalone = config.skills.find((s) => s.name === "sql_check")!;
     expect(standalone.mode).toBe("standalone");
-    expect(standalone.cli).toBe("claude");
-    expect(standalone.model).toBe("claude-sonnet-4-6");
-    expect(standalone.toolPolicy).toEqual({ type: "read_only" });
-    expect(standalone.timeoutMs).toBe(300000);
+    if (standalone.mode === "standalone") {
+      expect(standalone.cli).toBe("claude");
+      expect(standalone.model).toBe("claude-sonnet-4-6");
+      expect(standalone.toolPolicy).toEqual({ type: "read_only" });
+      expect(standalone.timeoutMs).toBe(300000);
+    }
   });
 
   it("defaults skills to empty array when not specified", async () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -617,3 +617,276 @@ lenses:
     expect(readability?.cli).toBe("claude");
   });
 });
+
+// ============================================================
+// Skills config
+// ============================================================
+
+const YAML_WITH_SKILLS = `
+version: "1.0"
+global:
+  max_rounds: 3
+  language: "en"
+  default_cli: "claude"
+  timeout_ms: 120000
+lenses:
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+  bug_risk:
+    enabled: true
+    model: "sonnet"
+    isolation: "repo"
+    tool_policy: "none"
+skills:
+  react_hooks:
+    enabled: true
+    mode: "inject"
+    prompt_file: "skills/react.md"
+    triggers:
+      file_patterns: ["**/*.tsx"]
+    attach_to: ["bug_risk"]
+  sql_check:
+    enabled: true
+    mode: "standalone"
+    prompt_file: "skills/sql.md"
+    triggers:
+      file_patterns: ["**/*.sql"]
+    cli: "claude"
+    model: "claude-sonnet-4-6"
+    isolation: "repo"
+    tool_policy: "read_only"
+    timeout_ms: 300000
+    severity_cap: "blocker"
+  always_skill:
+    enabled: false
+    mode: "inject"
+    prompt_file: "skills/always.md"
+    triggers:
+      always: true
+    attach_to: ["readability"]
+convergence:
+  round_severities:
+    - ["blocker", "warning", "nitpick"]
+  approve_condition: "zero_blockers"
+filters:
+  exclude_patterns: []
+`;
+
+describe("loadConfig skills", () => {
+  it("parses inject and standalone skills", async () => {
+    const path = await writeYamlConfig(YAML_WITH_SKILLS);
+    const config = await loadConfig(path);
+
+    // Only enabled skills are loaded
+    expect(config.skills).toHaveLength(2);
+
+    const inject = config.skills.find((s) => s.name === "react_hooks")!;
+    expect(inject.mode).toBe("inject");
+    expect(inject.promptFile).toBe("skills/react.md");
+    expect(inject.triggers.filePatterns).toEqual(["**/*.tsx"]);
+    expect(inject.attachTo).toEqual(["bug_risk"]);
+
+    const standalone = config.skills.find((s) => s.name === "sql_check")!;
+    expect(standalone.mode).toBe("standalone");
+    expect(standalone.cli).toBe("claude");
+    expect(standalone.model).toBe("claude-sonnet-4-6");
+    expect(standalone.toolPolicy).toEqual({ type: "read_only" });
+    expect(standalone.timeoutMs).toBe(300000);
+  });
+
+  it("defaults skills to empty array when not specified", async () => {
+    const path = await writeYamlConfig(FULL_YAML);
+    const config = await loadConfig(path);
+    expect(config.skills).toEqual([]);
+  });
+
+  /** Helper: wrap a skill YAML block in a minimal valid config */
+  const skillErrorYaml = (skillBlock: string) => `
+version: "1.0"
+global:
+  max_rounds: 3
+  language: "en"
+  default_cli: "claude"
+  timeout_ms: 120000
+lenses:
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+skills:
+${skillBlock}
+convergence:
+  round_severities:
+    - ["blocker"]
+  approve_condition: "zero_blockers"
+`;
+
+  it("throws when inject skill has no attach_to", async () => {
+    const path = await writeYamlConfig(skillErrorYaml(`
+  bad_skill:
+    enabled: true
+    mode: "inject"
+    prompt_file: "skills/bad.md"
+    triggers:
+      always: true`));
+    await expect(loadConfig(path)).rejects.toThrow(
+      'Inject skill "bad_skill" requires attach_to'
+    );
+  });
+
+  it("throws when inject skill references unknown lens", async () => {
+    const path = await writeYamlConfig(skillErrorYaml(`
+  bad_skill:
+    enabled: true
+    mode: "inject"
+    prompt_file: "skills/bad.md"
+    triggers:
+      always: true
+    attach_to: ["nonexistent_lens"]`));
+    await expect(loadConfig(path)).rejects.toThrow(
+      'targets unknown lens "nonexistent_lens"'
+    );
+  });
+
+  it("throws when standalone skill has no model", async () => {
+    const path = await writeYamlConfig(skillErrorYaml(`
+  bad_skill:
+    enabled: true
+    mode: "standalone"
+    prompt_file: "skills/bad.md"
+    triggers:
+      always: true`));
+    await expect(loadConfig(path)).rejects.toThrow(
+      'Standalone skill "bad_skill" requires a model'
+    );
+  });
+
+  it("throws when skill has no trigger condition", async () => {
+    const path = await writeYamlConfig(skillErrorYaml(`
+  bad_skill:
+    enabled: true
+    mode: "inject"
+    prompt_file: "skills/bad.md"
+    triggers:
+      file_patterns: []
+    attach_to: ["readability"]`));
+    await expect(loadConfig(path)).rejects.toThrow(
+      'requires at least one trigger condition'
+    );
+  });
+});
+
+// ============================================================
+// Output config
+// ============================================================
+
+describe("loadConfig output", () => {
+  it("defaults output to autoApprove: false, onIssues: comment", async () => {
+    const path = await writeYamlConfig(FULL_YAML);
+    const config = await loadConfig(path);
+
+    expect(config.output.github.autoApprove).toBe(false);
+    expect(config.output.github.onIssues).toBe("comment");
+  });
+
+  it("parses output config", async () => {
+    const path = await writeYamlConfig(`
+version: "1.0"
+global:
+  max_rounds: 3
+  language: "en"
+  default_cli: "claude"
+  timeout_ms: 120000
+lenses:
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+convergence:
+  round_severities:
+    - ["blocker"]
+  approve_condition: "zero_blockers"
+output:
+  github:
+    auto_approve: true
+    on_issues: "request_changes"
+`);
+    const config = await loadConfig(path);
+
+    expect(config.output.github.autoApprove).toBe(true);
+    expect(config.output.github.onIssues).toBe("request_changes");
+  });
+
+  it("partial output config uses defaults for missing fields", async () => {
+    const path = await writeYamlConfig(`
+version: "1.0"
+global:
+  max_rounds: 3
+  language: "en"
+  default_cli: "claude"
+  timeout_ms: 120000
+lenses:
+  readability:
+    enabled: true
+    model: "sonnet"
+    isolation: "tempdir"
+    tool_policy: "none"
+convergence:
+  round_severities:
+    - ["blocker"]
+  approve_condition: "zero_blockers"
+output:
+  github:
+    auto_approve: true
+`);
+    const config = await loadConfig(path);
+
+    expect(config.output.github.autoApprove).toBe(true);
+    expect(config.output.github.onIssues).toBe("comment");
+  });
+});
+
+// ============================================================
+// deepMergeRawConfig — skills and output
+// ============================================================
+
+describe("deepMergeRawConfig skills and output", () => {
+  it("merges skills from overlay", () => {
+    const base = makeRawConfig();
+    const overlay = {
+      skills: {
+        react: {
+          enabled: true,
+          mode: "inject",
+          prompt_file: "skills/react.md",
+          triggers: { always: true },
+          attach_to: ["readability"],
+        },
+      },
+    };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.skills).toBeDefined();
+    expect(merged.skills!["react"]).toMatchObject({
+      enabled: true,
+      mode: "inject",
+    });
+  });
+
+  it("merges output from overlay", () => {
+    const base = {
+      ...makeRawConfig(),
+      output: { github: { auto_approve: false, on_issues: "comment" as const } },
+    };
+    const overlay = { output: { github: { auto_approve: true } } };
+    const merged = deepMergeRawConfig(base, overlay);
+
+    expect(merged.output!.github!.auto_approve).toBe(true);
+    expect(merged.output!.github!.on_issues).toBe("comment");
+  });
+});

--- a/src/__tests__/skill-prompt-injector.test.ts
+++ b/src/__tests__/skill-prompt-injector.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFile, mkdtemp, rm, readFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { injectSkillContent } from "../skill-prompt-injector.js";
+import type { ResolvedPrompt } from "../prompt-resolver.js";
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+  tempDirs = [];
+});
+
+async function createBasePrompt(content: string): Promise<ResolvedPrompt> {
+  const dir = await mkdtemp(join(tmpdir(), "diffelens-inject-test-"));
+  tempDirs.push(dir);
+  const path = join(dir, "base-prompt.md");
+  await writeFile(path, content, "utf-8");
+  return {
+    absolutePath: path,
+    cleanup: async () => {},
+  };
+}
+
+describe("injectSkillContent", () => {
+  it("returns base prompt unchanged when no skill content", async () => {
+    const base = await createBasePrompt("Base prompt content.");
+    const result = await injectSkillContent(base, undefined, "test");
+
+    expect(result.absolutePath).toBe(base.absolutePath);
+  });
+
+  it("creates temp file with combined content when skill content provided", async () => {
+    const base = await createBasePrompt("Base prompt content.");
+    const result = await injectSkillContent(base, "Skill instructions here.", "test");
+
+    expect(result.absolutePath).not.toBe(base.absolutePath);
+    const combined = await readFile(result.absolutePath, "utf-8");
+    expect(combined).toContain("Base prompt content.");
+    expect(combined).toContain("## Additional Skill Context");
+    expect(combined).toContain("Skill instructions here.");
+
+    await result.cleanup();
+  });
+
+  it("cleanup removes the temp file", async () => {
+    const base = await createBasePrompt("Base.");
+    const result = await injectSkillContent(base, "Skill.", "test");
+
+    const tempPath = result.absolutePath;
+    await result.cleanup();
+
+    // Verify file is removed (readFile should throw)
+    await expect(readFile(tempPath, "utf-8")).rejects.toThrow();
+  });
+});

--- a/src/__tests__/skill-resolver.test.ts
+++ b/src/__tests__/skill-resolver.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFile, mkdir, mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { evaluateTriggers, resolveSkills } from "../skill-resolver.js";
+import type { ReviewConfig, SkillConfig, SkillTriggers } from "../config.js";
+
+// ============================================================
+// evaluateTriggers
+// ============================================================
+
+describe("evaluateTriggers", () => {
+  it("matches file_patterns against diff files", () => {
+    const triggers: SkillTriggers = {
+      filePatterns: ["**/*.tsx", "**/*.jsx"],
+    };
+    expect(evaluateTriggers(triggers, ["src/App.tsx"])).toBe(true);
+    expect(evaluateTriggers(triggers, ["src/utils.ts"])).toBe(false);
+  });
+
+  it("returns true when always is true", () => {
+    const triggers: SkillTriggers = { always: true };
+    expect(evaluateTriggers(triggers, [])).toBe(true);
+    expect(evaluateTriggers(triggers, ["any.file"])).toBe(true);
+  });
+
+  it("returns false when no conditions match", () => {
+    const triggers: SkillTriggers = {
+      filePatterns: ["**/*.py"],
+    };
+    expect(evaluateTriggers(triggers, ["src/index.ts"])).toBe(false);
+  });
+
+  it("matches nested file patterns", () => {
+    const triggers: SkillTriggers = {
+      filePatterns: ["**/repository/**"],
+    };
+    expect(evaluateTriggers(triggers, ["src/repository/user.ts"])).toBe(true);
+    expect(evaluateTriggers(triggers, ["src/service/auth.ts"])).toBe(false);
+  });
+
+  it("returns false for empty file_patterns", () => {
+    const triggers: SkillTriggers = { filePatterns: [] };
+    expect(evaluateTriggers(triggers, ["src/index.ts"])).toBe(false);
+  });
+});
+
+// ============================================================
+// resolveSkills
+// ============================================================
+
+let tempDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+  tempDirs = [];
+});
+
+function makeConfig(skills: SkillConfig[]): ReviewConfig {
+  return {
+    global: {
+      max_rounds: 3,
+      language: "en",
+      default_cli: "claude",
+      timeout_ms: 120000,
+    },
+    lenses: [
+      {
+        name: "bug_risk",
+        cli: "claude",
+        model: "claude-sonnet-4-6",
+        promptFile: "prompts/bug_risk.md",
+        promptSource: "builtin",
+        toolPolicy: { type: "none" },
+        timeoutMs: 120000,
+        isolation: "repo",
+        severityCap: "blocker",
+      },
+      {
+        name: "readability",
+        cli: "claude",
+        model: "claude-sonnet-4-6",
+        promptFile: "prompts/readability.md",
+        promptSource: "builtin",
+        toolPolicy: { type: "none" },
+        timeoutMs: 120000,
+        isolation: "tempdir",
+        severityCap: "warning",
+      },
+    ],
+    skills,
+    convergence: {
+      round_severities: [["blocker", "warning", "nitpick"]],
+      approve_condition: "zero_blockers",
+    },
+    filters: { exclude_patterns: [] },
+    output: { github: { autoApprove: false, onIssues: "comment" } },
+  };
+}
+
+describe("resolveSkills", () => {
+  it("resolves inject skill and groups by target lens", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-skill-test-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "skills"), { recursive: true });
+    await writeFile(join(dir, "skills/react.md"), "Check React hooks rules.", "utf-8");
+
+    const config = makeConfig([
+      {
+        name: "react_hooks",
+        enabled: true,
+        mode: "inject",
+        promptFile: "skills/react.md",
+        triggers: { filePatterns: ["**/*.tsx"] },
+        attachTo: ["bug_risk"],
+      },
+    ]);
+
+    const result = await resolveSkills(config, ["src/App.tsx"], dir);
+
+    expect(result.activatedSkills).toEqual(["react_hooks"]);
+    expect(result.injections.has("bug_risk")).toBe(true);
+    expect(result.injections.get("bug_risk")).toBe("Check React hooks rules.");
+    expect(result.standaloneSkills).toHaveLength(0);
+  });
+
+  it("does not activate skill when triggers do not match", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-skill-test-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "skills"), { recursive: true });
+    await writeFile(join(dir, "skills/react.md"), "Check React hooks rules.", "utf-8");
+
+    const config = makeConfig([
+      {
+        name: "react_hooks",
+        enabled: true,
+        mode: "inject",
+        promptFile: "skills/react.md",
+        triggers: { filePatterns: ["**/*.tsx"] },
+        attachTo: ["bug_risk"],
+      },
+    ]);
+
+    const result = await resolveSkills(config, ["src/utils.ts"], dir);
+
+    expect(result.activatedSkills).toEqual([]);
+    expect(result.injections.size).toBe(0);
+  });
+
+  it("resolves standalone skill as StandaloneSkillConfig", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-skill-test-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "skills"), { recursive: true });
+    await writeFile(join(dir, "skills/sql.md"), "Check SQL injection.", "utf-8");
+
+    const config = makeConfig([
+      {
+        name: "sql_check",
+        enabled: true,
+        mode: "standalone",
+        promptFile: "skills/sql.md",
+        triggers: { filePatterns: ["**/*.sql"] },
+        cli: "claude",
+        model: "claude-sonnet-4-6",
+        isolation: "repo",
+        toolPolicy: { type: "read_only" },
+        timeoutMs: 300000,
+        severityCap: "blocker",
+      },
+    ]);
+
+    const result = await resolveSkills(config, ["migrations/001.sql"], dir);
+
+    expect(result.activatedSkills).toEqual(["sql_check"]);
+    expect(result.standaloneSkills).toHaveLength(1);
+
+    const skill = result.standaloneSkills[0];
+    expect(skill.name).toBe("sql_check");
+    expect(skill.mode).toBe("standalone");
+    expect(skill.cli).toBe("claude");
+    expect(skill.model).toBe("claude-sonnet-4-6");
+    expect(skill.promptFile).toBe("skills/sql.md");
+    expect(skill.toolPolicy).toEqual({ type: "read_only" });
+  });
+
+  it("merges multiple inject skills into same lens", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-skill-test-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "skills"), { recursive: true });
+    await writeFile(join(dir, "skills/hooks.md"), "Hook rules.", "utf-8");
+    await writeFile(join(dir, "skills/standards.md"), "Coding standards.", "utf-8");
+
+    const config = makeConfig([
+      {
+        name: "hooks",
+        enabled: true,
+        mode: "inject",
+        promptFile: "skills/hooks.md",
+        triggers: { always: true },
+        attachTo: ["bug_risk"],
+      },
+      {
+        name: "standards",
+        enabled: true,
+        mode: "inject",
+        promptFile: "skills/standards.md",
+        triggers: { always: true },
+        attachTo: ["bug_risk"],
+      },
+    ]);
+
+    const result = await resolveSkills(config, ["any.ts"], dir);
+
+    expect(result.activatedSkills).toEqual(["hooks", "standards"]);
+    const injection = result.injections.get("bug_risk")!;
+    expect(injection).toContain("Hook rules.");
+    expect(injection).toContain("---");
+    expect(injection).toContain("Coding standards.");
+  });
+
+  it("skips disabled skills", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "diffelens-skill-test-"));
+    tempDirs.push(dir);
+    await mkdir(join(dir, "skills"), { recursive: true });
+    await writeFile(join(dir, "skills/react.md"), "Content", "utf-8");
+
+    const config = makeConfig([
+      {
+        name: "react_hooks",
+        enabled: false,
+        mode: "inject",
+        promptFile: "skills/react.md",
+        triggers: { always: true },
+        attachTo: ["bug_risk"],
+      },
+    ]);
+
+    const result = await resolveSkills(config, ["src/App.tsx"], dir);
+    expect(result.activatedSkills).toEqual([]);
+  });
+});

--- a/src/__tests__/summary-renderer.test.ts
+++ b/src/__tests__/summary-renderer.test.ts
@@ -128,9 +128,9 @@ describe("renderSummary with ReviewScope", () => {
     diffFiles: ["src/main.ts", "src/config.ts"],
     changeSummary: null,
     lensStats: [
-      { name: "readability", cli: "gemini", durationMs: 12300, success: true, assessment: "clean", exploredFiles: null, findingCount: 0 },
-      { name: "architectural", cli: "gemini", durationMs: 18500, success: true, assessment: "clean", exploredFiles: 8, findingCount: 0 },
-      { name: "bug_risk", cli: "gemini", durationMs: 21100, success: true, assessment: "minor_issues", exploredFiles: 5, findingCount: 3 },
+      { name: "readability", type: "lens", cli: "gemini", durationMs: 12300, success: true, assessment: "clean", exploredFiles: null, findingCount: 0 },
+      { name: "architectural", type: "lens", cli: "gemini", durationMs: 18500, success: true, assessment: "clean", exploredFiles: 8, findingCount: 0 },
+      { name: "bug_risk", type: "lens", cli: "gemini", durationMs: 21100, success: true, assessment: "minor_issues", exploredFiles: 5, findingCount: 3 },
     ],
   };
 
@@ -143,9 +143,9 @@ describe("renderSummary with ReviewScope", () => {
 
   it("renders per-lens stats table", () => {
     const result = renderSummary(makeState(), "approve", "github", scope);
-    expect(result).toContain("| readability | gemini | 12.3s | 2 files (diff) | clean |");
-    expect(result).toContain("| architectural | gemini | 18.5s | 8 files | clean |");
-    expect(result).toContain("| bug_risk | gemini | 21.1s | 5 files | minor issues (3) |");
+    expect(result).toContain("| readability | lens | gemini | 12.3s | 2 files (diff) | clean |");
+    expect(result).toContain("| architectural | lens | gemini | 18.5s | 8 files | clean |");
+    expect(result).toContain("| bug_risk | lens | gemini | 21.1s | 5 files | minor issues (3) |");
   });
 
   it("shows error for failed lens", () => {
@@ -154,8 +154,8 @@ describe("renderSummary with ReviewScope", () => {
       diffFiles: ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"],
       changeSummary: null,
       lensStats: [
-        { name: "readability", cli: "gemini", durationMs: 1200, success: false, assessment: null, exploredFiles: null, findingCount: null },
-        { name: "architectural", cli: "gemini", durationMs: 15000, success: true, assessment: "clean", exploredFiles: 3, findingCount: 0 },
+        { name: "readability", type: "lens", cli: "gemini", durationMs: 1200, success: false, assessment: null, exploredFiles: null, findingCount: null },
+        { name: "architectural", type: "lens", cli: "gemini", durationMs: 15000, success: true, assessment: "clean", exploredFiles: 3, findingCount: 0 },
       ],
     };
     const result = renderSummary(makeState(), "approve", "github", failedScope);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,18 +16,26 @@ export interface GlobalConfig {
   base_url?: string;
 }
 
-export interface LensConfig {
-  name: string;
+/** Shared execution fields between lenses and standalone skills */
+export interface ExecutionConfig {
   cli: CLIName;
   model: string;
-  promptFile: string;
-  promptSource: "builtin" | "custom" | "extended";
-  promptAppendFile?: string;
   toolPolicy: ToolPolicy;
   timeoutMs: number;
   isolation: "tempdir" | "repo";
   severityCap: "blocker" | "warning" | "nitpick";
   baseUrl?: string;
+}
+
+/** Minimal context needed to execute a review run (used by runLens) */
+export interface RunContext extends ExecutionConfig {
+  name: string;
+}
+
+export interface LensConfig extends RunContext {
+  promptFile: string;
+  promptSource: "builtin" | "custom" | "extended";
+  promptAppendFile?: string;
 }
 
 export interface ConvergenceConfig {
@@ -51,11 +59,45 @@ interface RawConvergenceNew {
 
 type RawConvergenceConfig = RawConvergenceLegacy | RawConvergenceNew;
 
+export interface SkillTriggers {
+  filePatterns?: string[];
+  always?: boolean;
+}
+
+interface SkillBase {
+  name: string;
+  enabled: boolean;
+  promptFile: string;
+  triggers: SkillTriggers;
+}
+
+export interface InjectSkillConfig extends SkillBase {
+  mode: "inject";
+  attachTo: string[];
+}
+
+export interface StandaloneSkillConfig extends SkillBase, ExecutionConfig {
+  mode: "standalone";
+}
+
+export type SkillConfig = InjectSkillConfig | StandaloneSkillConfig;
+
+export interface GitHubOutputConfig {
+  autoApprove: boolean;
+  onIssues: "request_changes" | "comment";
+}
+
+export interface OutputConfig {
+  github: GitHubOutputConfig;
+}
+
 export interface ReviewConfig {
   global: GlobalConfig;
   lenses: LensConfig[];
+  skills: SkillConfig[];
   convergence: ConvergenceConfig;
   filters: { exclude_patterns: string[] };
+  output: OutputConfig;
 }
 
 interface RawLensConfig {
@@ -71,6 +113,31 @@ interface RawLensConfig {
   base_url?: string;
 }
 
+interface RawSkillConfig {
+  enabled: boolean;
+  mode: "inject" | "standalone";
+  prompt_file: string;
+  triggers?: {
+    file_patterns?: string[];
+    always?: boolean;
+  };
+  attach_to?: string[];
+  cli?: CLIName;
+  model?: string;
+  isolation?: "tempdir" | "repo";
+  tool_policy?: "none" | "read_only" | "all" | { type: "explicit"; tools: string[] };
+  timeout_ms?: number;
+  severity_cap?: "blocker" | "warning" | "nitpick";
+  base_url?: string;
+}
+
+interface RawOutputConfig {
+  github?: {
+    auto_approve?: boolean;
+    on_issues?: "request_changes" | "comment";
+  };
+}
+
 interface RawConfig {
   version: string;
   global: {
@@ -81,8 +148,10 @@ interface RawConfig {
     base_url?: string;
   };
   lenses: Record<string, RawLensConfig>;
+  skills?: Record<string, RawSkillConfig>;
   convergence: RawConvergenceConfig;
   filters: { exclude_patterns: string[] };
+  output?: RawOutputConfig;
 }
 
 export const LOCAL_CONFIG_FILENAME = ".diffelens.local.yaml";
@@ -155,11 +224,148 @@ function normalizeRawConfig(raw: RawConfig): ReviewConfig {
     });
   }
 
+  const enabledLensNames = new Set(lenses.map((l) => l.name));
+  const allDeclaredLensNames = new Set(Object.keys(raw.lenses));
+  const skills = normalizeSkills(raw.skills ?? {}, raw.global, enabledLensNames, allDeclaredLensNames);
+  const output = normalizeOutput(raw.output);
+
   return {
     global: raw.global,
     lenses,
+    skills,
     convergence: normalizeConvergence(raw.convergence),
     filters: raw.filters ?? { exclude_patterns: [] },
+    output,
+  };
+}
+
+function validateSkillTriggers(name: string, skill: RawSkillConfig): SkillTriggers {
+  const triggers: SkillTriggers = {
+    filePatterns: skill.triggers?.file_patterns,
+    always: skill.triggers?.always,
+  };
+
+  const hasFilePatterns = (triggers.filePatterns?.length ?? 0) > 0;
+  if (!hasFilePatterns && triggers.always !== true) {
+    throw new Error(
+      `Skill "${name}" requires at least one trigger condition (file_patterns or always: true)`
+    );
+  }
+
+  return triggers;
+}
+
+function buildInjectSkill(
+  name: string,
+  skill: RawSkillConfig,
+  triggers: SkillTriggers,
+  enabledLensNames: Set<string>,
+  allDeclaredLensNames: Set<string>
+): InjectSkillConfig {
+  if (!skill.attach_to || skill.attach_to.length === 0) {
+    throw new Error(`Inject skill "${name}" requires attach_to with at least one lens name`);
+  }
+  for (const lensName of skill.attach_to) {
+    if (!enabledLensNames.has(lensName)) {
+      const lensStatus = allDeclaredLensNames.has(lensName) ? "disabled" : "unknown";
+      throw new Error(`Inject skill "${name}" targets ${lensStatus} lens "${lensName}" in attach_to`);
+    }
+  }
+
+  return {
+    name,
+    enabled: true,
+    mode: "inject",
+    promptFile: skill.prompt_file,
+    triggers,
+    attachTo: skill.attach_to,
+  };
+}
+
+function buildStandaloneSkill(
+  name: string,
+  skill: RawSkillConfig,
+  triggers: SkillTriggers,
+  globalConfig: RawConfig["global"]
+): StandaloneSkillConfig {
+  if (!skill.model) {
+    throw new Error(`Standalone skill "${name}" requires a model`);
+  }
+  if (skill.base_url) {
+    validateBaseUrl(skill.base_url, `skill "${name}"`);
+  }
+
+  return {
+    name,
+    enabled: true,
+    mode: "standalone",
+    promptFile: skill.prompt_file,
+    triggers,
+    cli: skill.cli ?? globalConfig.default_cli,
+    model: skill.model,
+    isolation: skill.isolation ?? "repo",
+    toolPolicy: skill.tool_policy ? normalizeToolPolicy(skill.tool_policy) : { type: "none" },
+    timeoutMs: skill.timeout_ms ?? globalConfig.timeout_ms,
+    severityCap: skill.severity_cap ?? "blocker",
+    baseUrl: skill.base_url ?? globalConfig.base_url,
+  };
+}
+
+function normalizeSkills(
+  rawSkills: Record<string, RawSkillConfig>,
+  globalConfig: RawConfig["global"],
+  enabledLensNames: Set<string>,
+  allDeclaredLensNames: Set<string>
+): SkillConfig[] {
+  const skills: SkillConfig[] = [];
+
+  for (const [name, skill] of Object.entries(rawSkills)) {
+    if (!skill.enabled) continue;
+
+    if (!skill.prompt_file) {
+      throw new Error(`Skill "${name}" requires a prompt_file`);
+    }
+
+    const triggers = validateSkillTriggers(name, skill);
+
+    if (skill.mode === "standalone") {
+      skills.push(buildStandaloneSkill(name, skill, triggers, globalConfig));
+    } else if (skill.mode === "inject") {
+      skills.push(buildInjectSkill(name, skill, triggers, enabledLensNames, allDeclaredLensNames));
+    } else {
+      throw new Error(
+        `Skill "${name}" has invalid mode "${skill.mode}". Valid values: inject, standalone`
+      );
+    }
+  }
+
+  return skills;
+}
+
+function defaultOutput(): OutputConfig {
+  return {
+    github: {
+      autoApprove: false,
+      onIssues: "comment",
+    },
+  };
+}
+
+function normalizeOutput(raw?: RawOutputConfig): OutputConfig {
+  if (!raw) return defaultOutput();
+
+  const onIssues = raw.github?.on_issues ?? "comment";
+  if (onIssues !== "request_changes" && onIssues !== "comment") {
+    throw new Error(
+      `Invalid output.github.on_issues: "${onIssues}". Valid values: request_changes, comment`
+    );
+  }
+
+  return {
+    github: {
+      autoApprove: raw.github?.auto_approve ?? false,
+      onIssues,
+    },
   };
 }
 
@@ -212,6 +418,33 @@ export function deepMergeRawConfig(base: RawConfig, overlay: Record<string, unkn
     if (overlayFilters.exclude_patterns) {
       merged.filters = { ...base.filters, exclude_patterns: overlayFilters.exclude_patterns };
     }
+  }
+
+  // skills: per-skill field-level merge (same pattern as lenses)
+  if (overlay.skills && typeof overlay.skills === "object") {
+    const overlaySkills = overlay.skills as Record<string, Partial<RawSkillConfig>>;
+    const mergedSkills = { ...(base.skills ?? {}) };
+    for (const [name, skillOverlay] of Object.entries(overlaySkills)) {
+      if (name in mergedSkills) {
+        mergedSkills[name] = { ...mergedSkills[name], ...skillOverlay };
+      } else {
+        mergedSkills[name] = skillOverlay as RawSkillConfig;
+      }
+    }
+    merged.skills = mergedSkills;
+  }
+
+  // output: deep merge github sub-object
+  if (overlay.output && typeof overlay.output === "object") {
+    const overlayOutput = overlay.output as Partial<RawOutputConfig>;
+    const baseOutput = base.output ?? {};
+    merged.output = {
+      ...baseOutput,
+      github: {
+        ...(baseOutput.github ?? {}),
+        ...(overlayOutput.github ?? {}),
+      },
+    };
   }
 
   // version: overlay wins if present

--- a/src/lens-runner.ts
+++ b/src/lens-runner.ts
@@ -3,16 +3,17 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { getAdapter } from "./adapters/index.js";
 import type { CLIRequest, LensOutput, Finding } from "./adapters/index.js";
-import type { LensConfig } from "./config.js";
+import type { RunContext } from "./config.js";
 import type { ReviewState } from "./state/review-state.js";
 import { SEVERITY_RANK } from "./severity.js";
 
 // ============================================================
-// Lens Execution: LensConfig -> CLIAdapter -> LensRunResult
+// Lens/Skill Execution: RunContext -> CLIAdapter -> LensRunResult
 // ============================================================
 
 export interface LensRunResult {
   lens: string;
+  type: "lens" | "skill";
   cli: string;
   output: LensOutput | null;
   durationMs: number;
@@ -21,12 +22,13 @@ export interface LensRunResult {
 }
 
 export async function runLens(
-  config: LensConfig,
+  config: RunContext,
   diff: string,
   state: ReviewState,
   repoRoot: string,
   resolvedPromptPath: string,
-  projectContext?: string
+  projectContext?: string,
+  type: "lens" | "skill" = "lens"
 ): Promise<LensRunResult> {
   const adapter = await getAdapter(config.cli);
 
@@ -70,6 +72,7 @@ export async function runLens(
       }
       return {
         lens: config.name,
+        type,
         cli: adapter.name,
         output: null,
         durationMs: response.durationMs,
@@ -92,6 +95,7 @@ export async function runLens(
 
     return {
       lens: config.name,
+      type,
       cli: adapter.name,
       output,
       durationMs: response.durationMs,
@@ -109,7 +113,7 @@ export async function runLens(
  */
 function applySeverityCap(
   parsed: LensOutput | null,
-  config: LensConfig
+  config: RunContext
 ): LensOutput | null {
   if (!parsed) return null;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,9 @@ import { filterDiffByExcludePatterns } from "./filters.js";
 import { resolveOptions, type RunOptions } from "./options.js";
 import { fetchDiff, hashDiff, resolveGitRef, parseDiffStats, parseDiffFiles } from "./diff.js";
 import { collectProjectContext, formatProjectContext } from "./project-context.js";
-import { resolvePrompt, validatePrompts } from "./prompt-resolver.js";
+import { resolvePrompt, resolveSkillPromptPath, validatePrompts, validateSkillPrompts } from "./prompt-resolver.js";
+import { resolveSkills, skillRunName } from "./skill-resolver.js";
+import { injectSkillContent } from "./skill-prompt-injector.js";
 import type { ReviewScope, LensStat } from "./output/summary-renderer.js";
 
 // ============================================================
@@ -178,29 +180,68 @@ export async function main(options?: RunOptions) {
     );
   }
 
-  // 7. Validate prompts + run all lenses in parallel
+  // 7. Validate all prompts (lenses + skills) before any I/O
   await validatePrompts(activeLenses, opts.repoRoot, opts.diffelensRoot);
+  if (config.skills.length > 0) {
+    await validateSkillPrompts(config.skills, opts.repoRoot);
+  }
+
+  // 8. Resolve skills (evaluate triggers against diff files)
+  const diffFiles = parseDiffFiles(diff);
+  const resolvedSkills = await resolveSkills(config, diffFiles, opts.repoRoot);
+
+  if (resolvedSkills.activatedSkills.length > 0) {
+    console.log(`Skills activated: ${resolvedSkills.activatedSkills.join(", ")}`);
+  }
 
   for (const lens of activeLenses) {
     console.log(`  [${lens.name}] prompt: ${lens.promptSource}${lens.promptAppendFile ? ` (+${lens.promptAppendFile})` : ""}`);
   }
 
+  // Filter standalone skills by CLI availability
+  const activeStandaloneSkills = resolvedSkills.standaloneSkills.filter((s) => {
+    if (!availability[s.cli]) {
+      console.warn(
+        `Warning: Skill "${s.name}" requires "${s.cli}" but not available. Skipping.`
+      );
+      return false;
+    }
+    return true;
+  });
+
+  const standaloneCount = activeStandaloneSkills.length;
+  const skillSuffix = standaloneCount > 0 ? ` + ${standaloneCount} standalone skills` : "";
   console.log(
-    `\nRunning ${activeLenses.length} lenses in parallel...\n`
+    `\nRunning ${activeLenses.length} lenses${skillSuffix} in parallel...\n`
   );
 
-  const results = await Promise.allSettled(
-    activeLenses.map(async (lens) => {
-      const resolved = await resolvePrompt(lens, opts.repoRoot, opts.diffelensRoot);
-      try {
-        return await runLens(lens, diff, state, opts.repoRoot, resolved.absolutePath, projectContextStr);
-      } finally {
-        await resolved.cleanup();
-      }
-    })
-  );
+  // 9. Run all lenses (with inject skills applied) + standalone skills in parallel
+  const lensPromises = activeLenses.map(async (lens) => {
+    let resolved: Awaited<ReturnType<typeof resolvePrompt>> | undefined;
+    let injected: Awaited<ReturnType<typeof injectSkillContent>> | undefined;
+    try {
+      resolved = await resolvePrompt(lens, opts.repoRoot, opts.diffelensRoot);
+      injected = await injectSkillContent(
+        resolved,
+        resolvedSkills.injections.get(lens.name),
+        lens.name,
+      );
+      return await runLens(lens, diff, state, opts.repoRoot, injected.absolutePath, projectContextStr, "lens");
+    } finally {
+      // Clean up whichever temp file was created last (injection wraps the resolved prompt)
+      await (injected ?? resolved)?.cleanup();
+    }
+  });
 
-  // 7. Collect results + build lens stats for review scope
+  const skillPromises = activeStandaloneSkills.map(async (skill) => {
+    const promptPath = resolveSkillPromptPath(skill.promptFile, opts.repoRoot);
+    const skillRunContext = { ...skill, name: skillRunName(skill.name) };
+    return await runLens(skillRunContext, diff, state, opts.repoRoot, promptPath, projectContextStr, "skill");
+  });
+
+  const results = await Promise.allSettled([...lensPromises, ...skillPromises]);
+
+  // 10. Collect results + build lens stats for review scope
   const allFindings: Finding[] = [];
   const lensStats: LensStat[] = [];
   for (const result of results) {
@@ -219,6 +260,7 @@ export async function main(options?: RunOptions) {
       }
       lensStats.push({
         name: r.lens,
+        type: r.type,
         cli: r.cli,
         durationMs: r.durationMs,
         success: r.success,
@@ -233,7 +275,7 @@ export async function main(options?: RunOptions) {
 
   console.log("");
 
-  // 8. Severity filter based on round (applies only to new findings)
+  // 11. Severity filter based on round (applies only to new findings)
   const filtered = filterBySeverityForRound(
     allFindings,
     state.current_round,
@@ -243,11 +285,11 @@ export async function main(options?: RunOptions) {
     `Findings: ${allFindings.length} raw -> ${filtered.length} after severity filter`
   );
 
-  // 9. Deduplicate
+  // 12. Deduplicate
   const deduplicated = deduplicateFindings(filtered);
   console.log(`  -> ${deduplicated.length} after deduplication`);
 
-  // 9a. Recurrence detection
+  // 12a. Recurrence detection
   const recurrence = detectAndSuppressRecurrences(state, deduplicated);
   if (recurrence.directives.length > 0) {
     console.log(
@@ -256,7 +298,7 @@ export async function main(options?: RunOptions) {
     );
   }
 
-  // 10. Update state
+  // 13. Update state
   const newState = updateState(state, recurrence.findings, headSha);
   const finalState = applyRecurrenceSuppressions(newState, recurrence.directives);
   const openCount = finalState.findings.filter(
@@ -267,12 +309,11 @@ export async function main(options?: RunOptions) {
   ).length;
   console.log(`  Open: ${openCount}, Resolved: ${resolvedCount}\n`);
 
-  // 11. Convergence decision
+  // 14. Convergence decision
   const decision = checkConvergence(finalState, config.convergence);
   console.log(`Decision: ${decision}`);
 
-  // 12. Build review scope for summary
-  const diffFiles = parseDiffFiles(diff);
+  // 15. Build review scope for summary
   const changeSummary = results
     .filter((r): r is PromiseFulfilledResult<LensRunResult> => r.status === "fulfilled")
     .map((r) => r.value.output?.change_summary)
@@ -285,9 +326,9 @@ export async function main(options?: RunOptions) {
     lensStats,
   };
 
-  // 13. Output: GitHub API for github mode with token, stdout otherwise
+  // 16. Output: GitHub API for github mode with token, stdout otherwise
   if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
-    await upsertSummaryComment(opts.prNumber, finalState, decision, scope);
+    await upsertSummaryComment(opts.prNumber, finalState, decision, scope, config.output);
   } else {
     const { renderSummary } = await import(
       "./output/summary-renderer.js"
@@ -296,7 +337,7 @@ export async function main(options?: RunOptions) {
     console.log(renderSummary(finalState, decision, opts.mode, scope));
   }
 
-  // 14. Save state (local mode only; GitHub mode persists via comment)
+  // 17. Save state (local mode only; GitHub mode persists via comment)
   if (opts.mode === "local") {
     await saveState(opts.stateDir, finalState);
   }

--- a/src/output/github-client.ts
+++ b/src/output/github-client.ts
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/rest";
 import type { ReviewState } from "../state/review-state.js";
 import type { ReviewDecision } from "../convergence.js";
+import type { OutputConfig } from "../config.js";
 import { renderSummary, MARKER, type ReviewScope } from "./summary-renderer.js";
 import { embedState, extractState } from "./comment-state.js";
 
@@ -60,7 +61,8 @@ export async function upsertSummaryComment(
   prNumber: number,
   state: ReviewState,
   decision: ReviewDecision,
-  scope?: ReviewScope
+  scope?: ReviewScope,
+  outputConfig?: OutputConfig
 ): Promise<void> {
   const octokit = getOctokit();
   const { owner, repo } = parseRepo();
@@ -95,21 +97,61 @@ export async function upsertSummaryComment(
     console.log(`  Summary comment created (comment_id: ${data.id})`);
   }
 
-  // Also set PR review status (optional)
-  if (decision === "approve") {
+  // Submit PR review based on output config
+  const reviewAction = resolveReviewAction(decision, outputConfig);
+  if (reviewAction) {
     try {
       await octokit.pulls.createReview({
         owner,
         repo,
         pull_number: prNumber,
-        event: "APPROVE",
-        body: "🤖 AI Review: All blockers resolved.",
+        event: reviewAction.event,
+        body: reviewAction.body,
       });
+      console.log(`  PR review submitted: ${reviewAction.event}`);
     } catch (e) {
-      // Ignore if no APPROVE permission
-      console.warn(`  Could not submit approval: ${e}`);
+      console.warn(`  Could not submit PR review (${reviewAction.event}): ${e}`);
     }
   }
+}
+
+/**
+ * Determine the PR review action based on convergence decision and output config.
+ *
+ * - autoApprove: false → never submit APPROVE or REQUEST_CHANGES
+ * - autoApprove: true + approve → APPROVE
+ * - autoApprove: true + request_changes → onIssues setting
+ * - onIssues: "comment" → no review action for issues
+ * - onIssues: "request_changes" → REQUEST_CHANGES review
+ */
+function resolveReviewAction(
+  decision: ReviewDecision,
+  outputConfig?: OutputConfig
+): { event: "APPROVE" | "REQUEST_CHANGES"; body: string } | null {
+  const githubConfig = outputConfig?.github;
+
+  // Default: no review actions. Previous versions auto-approved unconditionally;
+  // autoApprove now requires explicit opt-in via output.github.auto_approve: true.
+  if (!githubConfig?.autoApprove) return null;
+
+  if (decision === "approve") {
+    return {
+      event: "APPROVE",
+      body: "🤖 AI Review: All blockers resolved.",
+    };
+  }
+
+  if (
+    (decision === "request_changes" || decision === "escalate") &&
+    githubConfig.onIssues === "request_changes"
+  ) {
+    const body = decision === "escalate"
+      ? "🤖 AI Review: Escalated — unresolved issues after max rounds."
+      : "🤖 AI Review: Issues found that require attention.";
+    return { event: "REQUEST_CHANGES", body };
+  }
+
+  return null;
 }
 
 /**

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -10,6 +10,7 @@ const MARKER = "<!-- diffelens-summary -->";
 
 export interface LensStat {
   name: string;
+  type: "lens" | "skill";
   cli: string;
   durationMs: number;
   success: boolean;
@@ -157,9 +158,19 @@ function renderScope(scope: ReviewScope): string[] {
   const successCount = lensStats.filter((l) => l.success).length;
   const total = lensStats.length;
 
-  const lensLabel = successCount === total
-    ? `${total} lenses`
-    : `${successCount}/${total} lenses`;
+  const skillCount = lensStats.filter((l) => l.type === "skill").length;
+  const lensCount = total - skillCount;
+
+  let lensLabel: string;
+  if (skillCount > 0 && successCount === total) {
+    lensLabel = `${lensCount} lenses + ${skillCount} skills`;
+  } else if (skillCount > 0) {
+    lensLabel = `${successCount}/${total} (${lensCount} lenses + ${skillCount} skills)`;
+  } else if (successCount === total) {
+    lensLabel = `${total} lenses`;
+  } else {
+    lensLabel = `${successCount}/${total} lenses`;
+  }
 
   const summaryText = `${lensLabel} reviewed ${diffStats.files} files (+${diffStats.additions} -${diffStats.deletions})`;
 
@@ -179,8 +190,8 @@ function renderScope(scope: ReviewScope): string[] {
   }
 
   lines.push(
-    "| Lens | CLI | Duration | Explored | Result |",
-    "|------|-----|----------|----------|--------|",
+    "| Name | Type | CLI | Duration | Explored | Result |",
+    "|------|------|-----|----------|----------|--------|",
   );
 
   const diffFileCount = diffFiles.length;
@@ -191,7 +202,7 @@ function renderScope(scope: ReviewScope): string[] {
     const result = lens.success
       ? formatResult(lens.assessment, lens.findingCount)
       : "⚠️ error";
-    lines.push(`| ${lens.name} | ${lens.cli} | ${duration} | ${explored} | ${result} |`);
+    lines.push(`| ${lens.name} | ${lens.type} | ${lens.cli} | ${duration} | ${explored} | ${result} |`);
   }
 
   // Changed files list

--- a/src/prompt-resolver.ts
+++ b/src/prompt-resolver.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, rm } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import type { LensConfig } from "./config.js";
+import type { LensConfig, SkillConfig } from "./config.js";
 
 // ============================================================
 // Prompt Resolution: LensConfig -> absolute prompt file path
@@ -106,5 +106,34 @@ export async function validatePrompts(
 
   if (errors.length > 0) {
     throw new Error(`Prompt validation failed:\n  ${errors.join("\n  ")}`);
+  }
+}
+
+/**
+ * Resolve a skill's prompt file to an absolute path.
+ * Skill prompts are always custom (repo-relative), no builtin/extended logic.
+ */
+export function resolveSkillPromptPath(promptFile: string, repoRoot: string): string {
+  return join(repoRoot, promptFile);
+}
+
+/**
+ * Validate that all skill prompt files exist.
+ */
+export async function validateSkillPrompts(
+  skills: readonly SkillConfig[],
+  repoRoot: string,
+): Promise<void> {
+  const errors: string[] = [];
+
+  for (const skill of skills) {
+    const path = resolveSkillPromptPath(skill.promptFile, repoRoot);
+    if (!existsSync(path)) {
+      errors.push(`Skill "${skill.name}": prompt file not found at ${path}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Skill prompt validation failed:\n  ${errors.join("\n  ")}`);
   }
 }

--- a/src/skill-prompt-injector.ts
+++ b/src/skill-prompt-injector.ts
@@ -1,0 +1,39 @@
+import { readFile, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { ResolvedPrompt } from "./prompt-resolver.js";
+
+// ============================================================
+// Skill Prompt Injection: augment lens prompts with skill content
+// ============================================================
+
+/**
+ * Wrap a resolved prompt to append skill injection content.
+ * If no skill content is provided, returns the base prompt unchanged.
+ * Otherwise, creates a temp file with the combined content.
+ */
+export async function injectSkillContent(
+  basePrompt: ResolvedPrompt,
+  skillContent: string | undefined,
+  lensName: string,
+): Promise<ResolvedPrompt> {
+  if (!skillContent) return basePrompt;
+
+  const baseContent = await readFile(basePrompt.absolutePath, "utf-8");
+  const combined = `${baseContent}\n\n## Additional Skill Context\n\n${skillContent}`;
+
+  const tempPath = join(
+    tmpdir(),
+    `diffelens-skill-${lensName}-${Date.now()}.md`
+  );
+  await writeFile(tempPath, combined, "utf-8");
+
+  const baseCleanup = basePrompt.cleanup;
+  return {
+    absolutePath: tempPath,
+    cleanup: async () => {
+      await rm(tempPath, { force: true }).catch(() => {});
+      await baseCleanup().catch(() => {});
+    },
+  };
+}

--- a/src/skill-resolver.ts
+++ b/src/skill-resolver.ts
@@ -1,0 +1,85 @@
+import { readFile } from "fs/promises";
+import { globToRegex } from "./filters.js";
+import { resolveSkillPromptPath } from "./prompt-resolver.js";
+import type { ReviewConfig, StandaloneSkillConfig, SkillTriggers } from "./config.js";
+
+// ============================================================
+// Skill Resolution: evaluate triggers + build injections/standalone
+// ============================================================
+
+/** Prefix used to distinguish standalone skill names from lens names */
+export const SKILL_NAME_PREFIX = "skill:";
+
+export interface ResolvedSkills {
+  /** Map of lens name -> concatenated inject prompt content */
+  injections: Map<string, string>;
+  /** Standalone skills that matched triggers (ready to run via runLens) */
+  standaloneSkills: StandaloneSkillConfig[];
+  /** Names of activated skills (for logging) */
+  activatedSkills: string[];
+}
+
+/**
+ * Evaluate whether a skill's triggers match the current diff files.
+ */
+export function evaluateTriggers(
+  triggers: SkillTriggers,
+  diffFiles: string[],
+): boolean {
+  if (triggers.always) return true;
+
+  if (triggers.filePatterns && triggers.filePatterns.length > 0) {
+    const regexes = triggers.filePatterns.map(globToRegex);
+    return diffFiles.some((file) =>
+      regexes.some((re) => re.test(file))
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Resolve all enabled skills:
+ * - Evaluate triggers against diff files
+ * - Read inject skill prompt files and group by target lens
+ * - Collect standalone skills that matched triggers
+ */
+export async function resolveSkills(
+  config: ReviewConfig,
+  diffFiles: string[],
+  repoRoot: string,
+): Promise<ResolvedSkills> {
+  const injections = new Map<string, string>();
+  const standaloneSkills: StandaloneSkillConfig[] = [];
+  const activatedSkills: string[] = [];
+
+  for (const skill of config.skills) {
+    if (!skill.enabled) continue;
+    if (!evaluateTriggers(skill.triggers, diffFiles)) continue;
+
+    activatedSkills.push(skill.name);
+
+    if (skill.mode === "inject") {
+      const content = await readSkillPrompt(skill.promptFile, repoRoot);
+      for (const lensName of skill.attachTo ?? []) {
+        const existing = injections.get(lensName) ?? "";
+        const separator = existing ? "\n\n---\n\n" : "";
+        injections.set(lensName, `${existing}${separator}${content}`);
+      }
+    } else {
+      standaloneSkills.push(skill);
+    }
+  }
+
+  return { injections, standaloneSkills, activatedSkills };
+}
+
+/** Build the display name for a standalone skill (prefixed for output distinction) */
+export function skillRunName(skillName: string): string {
+  return `${SKILL_NAME_PREFIX}${skillName}`;
+}
+
+async function readSkillPrompt(promptFile: string, repoRoot: string): Promise<string> {
+  const absolutePath = resolveSkillPromptPath(promptFile, repoRoot);
+  return readFile(absolutePath, "utf-8");
+}


### PR DESCRIPTION
## Summary

- **Skills system**: Add dynamic review customization based on diff contents
  - **Inject mode**: Inject additional context into existing lens prompts (e.g., add React Hooks rules to bug_risk when `.tsx` files change)
  - **Standalone mode**: Run as an independent review lens in parallel (e.g., SQL security check when `.sql` files change)
  - Trigger conditions: `file_patterns` (glob) or `always: true`
- **Output config**: Control GitHub PR review actions (APPROVE / REQUEST_CHANGES) via `output.github`
- **RunContext type**: Generalize `runLens` to execute both lenses and skills uniformly

## Breaking Change

**Default behavior for PR auto-approve has changed.**

| | Before | After |
|---|---|---|
| APPROVE submission | Sent unconditionally | Only when `output.github.auto_approve: true` is explicitly set |

If you rely on automatic APPROVE, add the following to your `.diffelens.yaml`:

```yaml
output:
  github:
    auto_approve: true
    on_issues: comment  # or "request_changes"
```

## Config example

```yaml
skills:
  react_hooks:
    enabled: true
    mode: inject
    prompt_file: skills/react-hooks.md
    triggers:
      file_patterns: ["**/*.tsx", "**/*.jsx"]
    attach_to: [bug_risk]

  sql_security:
    enabled: true
    mode: standalone
    prompt_file: skills/sql-security.md
    triggers:
      file_patterns: ["**/*.sql", "**/repository/**"]
    cli: claude
    model: claude-sonnet-4-6
    isolation: repo
    tool_policy: read_only
```

## Test plan

- [x] All 211 tests pass (including 47 config, 10 skill-resolver, 3 skill-prompt-injector)
- [ ] Verify existing projects without `skills` in `.diffelens.yaml` work unchanged
- [ ] Inject mode: confirm prompt injection into target lens when triggers match
- [ ] Standalone mode: confirm parallel execution as independent lens
- [ ] Verify APPROVE is not sent when `output.github.auto_approve` is unset