### PR TITLE
feat: 3-layer progressive disclosure UX for PR reviews

### DIFF
--- a/.diffelens.yaml
+++ b/.diffelens.yaml
@@ -55,3 +55,11 @@ convergence:
     - ["blocker", "warning"]              # round 3: drop nitpick
     - ["blocker"]                         # round 4: blocker only
   approve_condition: "zero_blockers"
+
+output:
+  github:
+    auto_approve: true
+    on_issues: "request_changes"
+    inline_comments: true
+    max_inline_comments: 25
+    inline_severities: ["blocker", "warning"]

--- a/.diffelens.yaml
+++ b/.diffelens.yaml
@@ -54,7 +54,7 @@ convergence:
     - ["blocker", "warning", "nitpick"]   # round 2: all
     - ["blocker", "warning"]              # round 3: drop nitpick
     - ["blocker"]                         # round 4: blocker only
-  approve_condition: "zero_blockers"
+  approve_condition: "zero_blockers_and_warnings"
 
 output:
   github:

--- a/.github/workflows/ai-review-commands.yml
+++ b/.github/workflows/ai-review-commands.yml
@@ -61,16 +61,18 @@ jobs:
       - name: Fetch parent comment body
         id: parent
         run: |
-          if [ -n "${{ github.event.comment.in_reply_to_id }}" ]; then
-            BODY=$(gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.in_reply_to_id }} --jq '.body')
+          if [ -n "$IN_REPLY_TO_ID" ]; then
+            BODY=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/comments/${IN_REPLY_TO_ID}" --jq '.body')
           else
-            BODY="${{ github.event.comment.body }}"
+            BODY="$COMMENT_BODY"
           fi
           echo "body<<DELIM" >> "$GITHUB_OUTPUT"
           echo "$BODY" >> "$GITHUB_OUTPUT"
           echo "DELIM" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IN_REPLY_TO_ID: ${{ github.event.comment.in_reply_to_id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
 
       - name: Handle dismiss
         run: npx tsx src/handle-command.ts
@@ -81,4 +83,5 @@ jobs:
           COMMAND_BODY: ${{ github.event.comment.body }}
           COMMAND_USER: ${{ github.event.comment.user.login }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_TYPE: review_comment
           PARENT_COMMENT_BODY: ${{ steps.parent.outputs.body }}

--- a/.github/workflows/ai-review-commands.yml
+++ b/.github/workflows/ai-review-commands.yml
@@ -3,14 +3,18 @@ name: AI Review Commands
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   pull-requests: write
   contents: read
 
 jobs:
-  handle-command:
+  # Handle /diffelens dismiss in PR issue comments
+  handle-issue-comment:
     if: |
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/diffelens')
     runs-on: ubuntu-latest
@@ -26,13 +30,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download review state
-        uses: actions/download-artifact@v4
-        with:
-          name: review-state-pr-${{ github.event.issue.number }}
-          path: .diffelens-state/
-        continue-on-error: true
-
       - name: Handle command
         run: npx tsx src/handle-command.ts
         env:
@@ -43,9 +40,45 @@ jobs:
           COMMAND_USER: ${{ github.event.comment.user.login }}
           COMMENT_ID: ${{ github.event.comment.id }}
 
-      - name: Upload review state
-        uses: actions/upload-artifact@v4
+  # Handle /dismiss in inline review comment replies
+  handle-review-comment:
+    if: |
+      github.event_name == 'pull_request_review_comment' &&
+      startsWith(github.event.comment.body, '/dismiss')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          name: review-state-pr-${{ github.event.issue.number }}
-          path: .diffelens-state/
-          overwrite: true
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch parent comment body
+        id: parent
+        run: |
+          if [ -n "${{ github.event.comment.in_reply_to_id }}" ]; then
+            BODY=$(gh api repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.in_reply_to_id }} --jq '.body')
+          else
+            BODY="${{ github.event.comment.body }}"
+          fi
+          echo "body<<DELIM" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "DELIM" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Handle dismiss
+        run: npx tsx src/handle-command.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMAND_BODY: ${{ github.event.comment.body }}
+          COMMAND_USER: ${{ github.event.comment.user.login }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PARENT_COMMENT_BODY: ${{ steps.parent.outputs.body }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,10 +23,28 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # Resolve PR metadata first (gh CLI works without checkout)
+      - name: Resolve PR info
+        id: pr
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" \
+              --json baseRefOid,headRefOid \
+              --jq '"base_sha=\(.baseRefOid)\nhead_sha=\(.headRefOid)"' >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ steps.pr.outputs.head_sha }}
 
       - uses: actions/setup-node@v4
         with:
@@ -45,23 +63,6 @@ jobs:
 
       - name: Install orchestrator dependencies
         run: npm ci
-
-      # Resolve PR metadata (supports both pull_request and workflow_dispatch triggers)
-      - name: Resolve PR info
-        id: pr
-        run: |
-          if [ -n "${{ github.event.pull_request.number }}" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
-            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            PR_NUMBER="${{ github.event.inputs.pr_number }}"
-            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-            gh pr view "$PR_NUMBER" --json baseRefOid,headRefOid \
-              --jq '"base_sha=\(.baseRefOid)\nhead_sha=\(.headRefOid)"' >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Run review (state is persisted in the PR comment)
       - name: Run AI Review

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -45,6 +46,23 @@ jobs:
       - name: Install orchestrator dependencies
         run: npm ci
 
+      # Resolve PR metadata (supports both pull_request and workflow_dispatch triggers)
+      - name: Resolve PR info
+        id: pr
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base_sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            gh pr view "$PR_NUMBER" --json baseRefOid,headRefOid \
+              --jq '"base_sha=\(.baseRefOid)\nhead_sha=\(.headRefOid)"' >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Run review (state is persisted in the PR comment)
       - name: Run AI Review
         run: npx tsx src/main.ts
@@ -54,7 +72,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           CONFIG_PATH: ${{ github.workspace }}/.diffelens.yaml

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,10 +3,19 @@ name: AI PR Review
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
 
 permissions:
   pull-requests: write
   contents: read
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
 
 jobs:
   ai-review:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 coverage/
 .vscode/
 .idea/
+.diffelens.polish-skill.md

--- a/prompts/architectural.md
+++ b/prompts/architectural.md
@@ -58,7 +58,9 @@ Do NOT wrap in code fences. Return pure JSON only.
       "category": "layer_violation",
       "summary": "Description of the issue",
       "suggestion": "Specific improvement suggestion",
-      "references": ["paths/to/referenced/files"]
+      "references": ["paths/to/referenced/files"],
+      "evidence": "Brief explanation of why this was flagged (e.g., which principle is violated, what file/pattern was checked)",
+      "suggestion_diff": "Exact replacement code for the lines (optional, only for simple/obvious fixes)"
     }
   ],
   "explored_files": ["list of files the agent referenced"],

--- a/prompts/bug_risk.md
+++ b/prompts/bug_risk.md
@@ -56,7 +56,9 @@ Do NOT wrap in code fences. Return pure JSON only.
       "category": "null_safety",
       "summary": "Description of the issue",
       "suggestion": "Specific improvement suggestion",
-      "scenario": "Under what conditions the bug would occur"
+      "scenario": "Under what conditions the bug would occur",
+      "evidence": "Brief explanation of why this was flagged (e.g., type definition found, missing guard observed)",
+      "suggestion_diff": "Exact replacement code for the lines (optional, only for simple/obvious fixes)"
     }
   ],
   "explored_files": ["list of files the agent referenced"],

--- a/prompts/readability.md
+++ b/prompts/readability.md
@@ -49,7 +49,9 @@ Do NOT wrap in code fences. Return pure JSON only.
       "severity": "warning",
       "category": "naming",
       "summary": "Description of the issue",
-      "suggestion": "Specific improvement suggestion"
+      "suggestion": "Specific improvement suggestion",
+      "evidence": "Brief explanation of why this was flagged (what code pattern triggered it)",
+      "suggestion_diff": "Exact replacement code for the lines (optional, only for simple fixes like renames or typos)"
     }
   ],
   "change_summary": "Brief 1-2 sentence summary of what this PR changes",

--- a/src/__tests__/diff.test.ts
+++ b/src/__tests__/diff.test.ts
@@ -190,6 +190,7 @@ function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
     diffTarget: "all",
     cliBase: undefined,
     cliHead: undefined,
+    outputFile: undefined,
     ...overrides,
   };
 }

--- a/src/__tests__/skill-resolver.test.ts
+++ b/src/__tests__/skill-resolver.test.ts
@@ -96,7 +96,15 @@ function makeConfig(skills: SkillConfig[]): ReviewConfig {
       approve_condition: "zero_blockers",
     },
     filters: { exclude_patterns: [] },
-    output: { github: { autoApprove: false, onIssues: "comment" } },
+    output: {
+      github: {
+        autoApprove: false,
+        onIssues: "comment",
+        inlineComments: false,
+        maxInlineComments: 25,
+        inlineSeverities: ["blocker", "warning"],
+      },
+    },
   };
 }
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -73,6 +73,10 @@ export interface Finding {
   suggestion: string;
   scenario?: string;
   references?: string[];
+  /** Exact replacement code for GitHub suggestion block (simple fixes only) */
+  suggestion_diff?: string;
+  /** Brief explanation of why this was flagged */
+  evidence?: string;
   // Assigned by lens-runner
   lens?: string;
   id?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -390,7 +390,7 @@ function normalizeOutput(raw?: RawOutputConfig): OutputConfig {
       autoApprove: raw.github?.auto_approve ?? false,
       onIssues,
       inlineComments: raw.github?.inline_comments ?? false,
-      maxInlineComments: raw.github?.max_inline_comments ?? 25,
+      maxInlineComments: raw.github?.max_inline_comments ?? DEFAULT_MAX_INLINE_COMMENTS,
       inlineSeverities,
     },
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import { parse as parseYaml } from "yaml";
 import type { CLIName, ToolPolicy } from "./adapters/index.js";
-import { VALID_SEVERITIES } from "./severity.js";
+import { VALID_SEVERITIES, type Severity } from "./severity.js";
 
 // ============================================================
 // Type definitions and loader for .diffelens.yaml
@@ -85,6 +85,12 @@ export type SkillConfig = InjectSkillConfig | StandaloneSkillConfig;
 export interface GitHubOutputConfig {
   autoApprove: boolean;
   onIssues: "request_changes" | "comment";
+  /** Post findings as inline review comments on the code (default: false) */
+  inlineComments: boolean;
+  /** Maximum number of inline comments per review (default: 25) */
+  maxInlineComments: number;
+  /** Severity levels to post as inline comments (default: ["blocker", "warning"]) */
+  inlineSeverities: Severity[];
 }
 
 export interface OutputConfig {
@@ -135,6 +141,9 @@ interface RawOutputConfig {
   github?: {
     auto_approve?: boolean;
     on_issues?: "request_changes" | "comment";
+    inline_comments?: boolean;
+    max_inline_comments?: number;
+    inline_severities?: Severity[];
   };
 }
 
@@ -342,11 +351,17 @@ function normalizeSkills(
   return skills;
 }
 
+const DEFAULT_INLINE_SEVERITIES: Severity[] = ["blocker", "warning"];
+const DEFAULT_MAX_INLINE_COMMENTS = 25;
+
 function defaultOutput(): OutputConfig {
   return {
     github: {
       autoApprove: false,
       onIssues: "comment",
+      inlineComments: false,
+      maxInlineComments: DEFAULT_MAX_INLINE_COMMENTS,
+      inlineSeverities: DEFAULT_INLINE_SEVERITIES,
     },
   };
 }
@@ -361,10 +376,22 @@ function normalizeOutput(raw?: RawOutputConfig): OutputConfig {
     );
   }
 
+  const inlineSeverities = raw.github?.inline_severities ?? DEFAULT_INLINE_SEVERITIES;
+  for (const sev of inlineSeverities) {
+    if (!VALID_SEVERITIES.has(sev)) {
+      throw new Error(
+        `Invalid severity "${sev}" in output.github.inline_severities. Valid values: ${[...VALID_SEVERITIES].join(", ")}`
+      );
+    }
+  }
+
   return {
     github: {
       autoApprove: raw.github?.auto_approve ?? false,
       onIssues,
+      inlineComments: raw.github?.inline_comments ?? false,
+      maxInlineComments: raw.github?.max_inline_comments ?? 25,
+      inlineSeverities,
     },
   };
 }

--- a/src/handle-command.ts
+++ b/src/handle-command.ts
@@ -1,28 +1,161 @@
 import type { ReviewState } from "./state/review-state.js";
 import { loadState, saveState } from "./state/review-state.js";
-import { renderSummary, MARKER } from "./output/summary-renderer.js";
+import { extractFindingIdFromBody } from "./output/inline-comments.js";
 import {
   getOctokit,
   parseRepo,
-  findSummaryComment,
+  upsertSummaryComment,
 } from "./output/github-client.js";
 import { checkConvergence } from "./convergence.js";
 import { loadConfig } from "./config.js";
 
 // ============================================================
 // Handle /diffelens dismiss {id} {reason} command
+//
+// Supports three invocation modes:
+// 1. GitHub issue comment: /diffelens dismiss {id} {reason}
+// 2. GitHub review comment reply: /dismiss {reason} (ID extracted from parent)
+// 3. Local CLI: npx tsx src/handle-command.ts dismiss {id} {reason}
 // ============================================================
 
-async function main() {
+/** Core dismiss logic shared by all invocation modes */
+function applyDismiss(
+  state: ReviewState,
+  findingId: string,
+  reason: string,
+  actor: string
+): ReviewState | null {
+  const targetIndex = state.findings.findIndex((f) => f.id === findingId);
+  if (targetIndex === -1) {
+    console.error(`Finding "${findingId}" not found.`);
+    return null;
+  }
+
+  const target = state.findings[targetIndex];
+  if (target.status !== "open") {
+    console.log(`Finding "${findingId}" is already ${target.status}. Skipping.`);
+    return null;
+  }
+
+  const updatedFindings = state.findings.map((f, i) =>
+    i === targetIndex
+      ? {
+          ...f,
+          status: "wontfix" as const,
+          resolution_note: `Dismissed by @${actor}: ${reason || "no reason given"}`,
+        }
+      : f
+  );
+
+  return {
+    ...state,
+    findings: updatedFindings,
+    decisions: [
+      ...state.decisions,
+      `Round ${state.current_round}: ${findingId} dismissed as wontfix by @${actor} (${reason || "no reason"})`,
+    ],
+  };
+}
+
+/** Update the GitHub summary comment with new state via upsertSummaryComment */
+async function updateGitHubSummary(
+  updatedState: ReviewState,
+  prNumber: number
+): Promise<void> {
+  const configPath = process.env.CONFIG_PATH ?? ".diffelens.yaml";
+  const config = await loadConfig(configPath);
+  const decision = checkConvergence(updatedState, config.convergence);
+  await upsertSummaryComment(prNumber, updatedState, decision, undefined, config.output);
+}
+
+/** React to a comment with +1 */
+async function reactToComment(commentId: number): Promise<void> {
+  if (!commentId) return;
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo();
+  await octokit.reactions.createForIssueComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    content: "+1",
+  }).catch(() => {});
+}
+
+/** Load state, apply dismiss, save, and optionally update GitHub */
+async function executeDismiss(
+  stateDir: string,
+  prNumber: number,
+  findingId: string,
+  reason: string,
+  actor: string
+): Promise<void> {
+  const state = await loadState(stateDir, prNumber);
+  if (!state) {
+    console.error("No review state found.");
+    return;
+  }
+
+  const updatedState = applyDismiss(state, findingId, reason, actor);
+  if (!updatedState) return;
+
+  await saveState(stateDir, updatedState);
+
+  if (process.env.GITHUB_TOKEN) {
+    await updateGitHubSummary(updatedState, prNumber);
+    const commentId = parseInt(process.env.COMMENT_ID ?? "0") || 0;
+    await reactToComment(commentId);
+  }
+
+  console.log(`Done. Finding ${findingId} marked as wontfix.`);
+}
+
+// ============================================================
+// Mode 3: Local CLI — npx tsx src/handle-command.ts dismiss {id} {reason}
+// ============================================================
+async function handleLocalDismiss(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args[0] !== "dismiss" || !args[1]) {
+    console.log("Usage: npx tsx src/handle-command.ts dismiss <finding-id> [reason]");
+    return;
+  }
+
+  const findingId = args[1];
+  const reason = args.slice(2).join(" ") || "no reason given";
+  const stateDir = process.env.STATE_DIR ?? ".diffelens-state";
+  const prNumber = parseInt(process.env.PR_NUMBER ?? "0");
+
+  await executeDismiss(stateDir, prNumber, findingId, reason, "local-user");
+}
+
+// ============================================================
+// Mode 1 & 2: GitHub — env var driven
+// ============================================================
+async function handleGitHubDismiss(): Promise<void> {
   const prNumber = parseInt(process.env.PR_NUMBER ?? "0");
   const commandBody = process.env.COMMAND_BODY ?? "";
   const commandUser = process.env.COMMAND_USER ?? "unknown";
   const stateDir = process.env.STATE_DIR ?? ".diffelens-state";
 
+  // Mode 2: Review comment reply — /dismiss {reason}
+  // PARENT_COMMENT_BODY contains the inline comment body with **[id]**
+  const parentBody = process.env.PARENT_COMMENT_BODY;
+  if (parentBody) {
+    const findingId = extractFindingIdFromBody(parentBody);
+    if (!findingId) {
+      console.log("Could not extract finding ID from parent comment.");
+      return;
+    }
+    const reason = commandBody.replace(/^\/dismiss\s*/, "").trim() || "no reason given";
+    console.log(`Thread dismiss: ${findingId}, reason: ${reason}`);
+    await executeDismiss(stateDir, prNumber, findingId, reason, commandUser);
+    return;
+  }
+
+  // Mode 1: Issue comment — /diffelens dismiss {id} {reason}
   console.log(`Command: ${commandBody}`);
   console.log(`User: ${commandUser}`);
 
-  // Parse command
   const match = commandBody.match(
     /^\/diffelens\s+dismiss\s+(\S+)\s*(.*)?$/
   );
@@ -34,89 +167,23 @@ async function main() {
 
   const [, findingId, reason] = match;
   console.log(`Dismissing: ${findingId}, reason: ${reason || "none"}`);
+  await executeDismiss(stateDir, prNumber, findingId, reason || "", commandUser);
+}
 
-  // Load state (via shared module)
-  const state = await loadState(stateDir, prNumber);
-  if (!state) {
-    console.error("No review state found for this PR.");
+// ============================================================
+// Entry point: detect mode from args vs env vars
+// ============================================================
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Local CLI mode: first arg is "dismiss"
+  if (args[0] === "dismiss") {
+    await handleLocalDismiss();
     return;
   }
 
-  // Update finding status (immutably)
-  const targetIndex = state.findings.findIndex((f) => f.id === findingId);
-  if (targetIndex === -1) {
-    console.error(`Finding "${findingId}" not found.`);
-    return;
-  }
-
-  const target = state.findings[targetIndex];
-  if (target.status !== "open") {
-    console.log(
-      `Finding "${findingId}" is already ${target.status}. Skipping.`
-    );
-    return;
-  }
-
-  const updatedFindings = state.findings.map((f, i) =>
-    i === targetIndex
-      ? {
-          ...f,
-          status: "wontfix" as const,
-          resolution_note: `Dismissed by @${commandUser}: ${reason || "no reason given"}`,
-        }
-      : f
-  );
-
-  const updatedState: ReviewState = {
-    ...state,
-    findings: updatedFindings,
-    decisions: [
-      ...state.decisions,
-      `Round ${state.current_round}: ${findingId} dismissed as wontfix by @${commandUser} (${reason || "no reason"})`,
-    ],
-  };
-
-  // Save state (via shared module)
-  await saveState(stateDir, updatedState);
-
-  // Update summary comment (via shared module)
-  if (process.env.GITHUB_TOKEN) {
-    const configPath = process.env.CONFIG_PATH ?? ".diffelens.yaml";
-    const config = await loadConfig(configPath);
-
-    const decision = checkConvergence(updatedState, config.convergence);
-    const body = renderSummary(updatedState, decision);
-
-    const octokit = getOctokit();
-    const { owner, repo } = parseRepo();
-
-    const existingCommentId = await findSummaryComment(
-      octokit,
-      owner,
-      repo,
-      prNumber
-    );
-
-    if (existingCommentId) {
-      await octokit.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existingCommentId,
-        body,
-      });
-      console.log("Summary comment updated.");
-    }
-
-    // Confirm with a reaction
-    await octokit.reactions.createForIssueComment({
-      owner,
-      repo,
-      comment_id: parseInt(process.env.COMMENT_ID ?? "0") || 0,
-      content: "+1",
-    }).catch(() => {});
-  }
-
-  console.log(`Done. Finding ${findingId} marked as wontfix.`);
+  // GitHub mode: driven by env vars
+  await handleGitHubDismiss();
 }
 
 main().catch(console.error);

--- a/src/handle-command.ts
+++ b/src/handle-command.ts
@@ -5,6 +5,7 @@ import {
   getOctokit,
   parseRepo,
   upsertSummaryComment,
+  loadStateFromComment,
 } from "./output/github-client.js";
 import { checkConvergence } from "./convergence.js";
 import { loadConfig } from "./config.js";
@@ -89,7 +90,11 @@ async function executeDismiss(
   reason: string,
   actor: string
 ): Promise<void> {
-  const state = await loadState(stateDir, prNumber);
+  // Try file state first, then fall back to PR comment state (GitHub mode)
+  let state = await loadState(stateDir, prNumber);
+  if (!state && process.env.GITHUB_TOKEN && prNumber > 0) {
+    state = await loadStateFromComment(prNumber);
+  }
   if (!state) {
     console.error("No review state found.");
     return;

--- a/src/handle-command.ts
+++ b/src/handle-command.ts
@@ -69,17 +69,18 @@ async function updateGitHubSummary(
   await upsertSummaryComment(prNumber, updatedState, decision, undefined, config.output);
 }
 
-/** React to a comment with +1 */
-async function reactToComment(commentId: number): Promise<void> {
+type CommentType = "issue_comment" | "review_comment";
+
+/** React to a comment with +1 (supports both issue and review comments) */
+async function reactToComment(commentId: number, commentType: CommentType = "issue_comment"): Promise<void> {
   if (!commentId) return;
   const octokit = getOctokit();
   const { owner, repo } = parseRepo();
-  await octokit.reactions.createForIssueComment({
-    owner,
-    repo,
-    comment_id: commentId,
-    content: "+1",
-  }).catch(() => {});
+  const createReaction = commentType === "review_comment"
+    ? octokit.reactions.createForPullRequestReviewComment
+    : octokit.reactions.createForIssueComment;
+  // Best-effort: reaction is non-critical
+  await createReaction({ owner, repo, comment_id: commentId, content: "+1" }).catch(() => {});
 }
 
 /** Load state, apply dismiss, save, and optionally update GitHub */
@@ -108,7 +109,8 @@ async function executeDismiss(
   if (process.env.GITHUB_TOKEN) {
     await updateGitHubSummary(updatedState, prNumber);
     const commentId = parseInt(process.env.COMMENT_ID ?? "0") || 0;
-    await reactToComment(commentId);
+    const commentType: CommentType = process.env.COMMENT_TYPE === "review_comment" ? "review_comment" : "issue_comment";
+    await reactToComment(commentId, commentType);
   }
 
   console.log(`Done. Finding ${findingId} marked as wontfix.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -353,7 +353,7 @@ export async function main(options?: RunOptions) {
     process.env.GITHUB_TOKEN &&
     config.output.github.inlineComments
   )
-    ? await postInlineAndMergeState(opts.prNumber, finalState, headSha, diffFiles, config.output)
+    ? await postInlineAndMergeState(opts.prNumber, finalState, headSha, diffFiles, config.output, diff)
     : finalState;
 
   if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
@@ -428,11 +428,12 @@ async function postInlineAndMergeState(
   state: ReviewState,
   headSha: string,
   diffFiles: string[],
-  outputConfig: OutputConfig
+  outputConfig: OutputConfig,
+  diff?: string
 ): Promise<ReviewState> {
   const modifiedFiles = new Set(diffFiles);
   const inlineResult = await submitInlineReview(
-    prNumber, state, headSha, modifiedFiles, outputConfig
+    prNumber, state, headSha, modifiedFiles, outputConfig, diff
   );
 
   if (Object.keys(inlineResult.postedComments).length === 0) return state;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { join } from "path";
 import { existsSync, realpathSync } from "fs";
+import { writeFile } from "fs/promises";
 import { fileURLToPath } from "url";
 import { loadConfig, loadConfigWithFallback, loadConfigWithLocalOverlay, LOCAL_CONFIG_FILENAME } from "./config.js";
 import { runLens, type LensRunResult } from "./lens-runner.js";
@@ -11,6 +12,7 @@ import {
   updateState,
   saveState,
   applyRecurrenceSuppressions,
+  buildInlineCommentMap,
 } from "./state/review-state.js";
 import { deduplicateFindings } from "./deduplicator.js";
 import { detectAndSuppressRecurrences } from "./recurrence.js";
@@ -23,6 +25,10 @@ import {
   postEscalationComment,
   loadStateFromComment,
 } from "./output/github-client.js";
+import {
+  submitInlineReview,
+  fetchResolvedThreads,
+} from "./output/inline-review-client.js";
 import { checkAvailability, type Finding } from "./adapters/index.js";
 import { filterDiffByExcludePatterns } from "./filters.js";
 import { resolveOptions, type RunOptions } from "./options.js";
@@ -32,6 +38,8 @@ import { resolvePrompt, resolveSkillPromptPath, validatePrompts, validateSkillPr
 import { resolveSkills, skillRunName } from "./skill-resolver.js";
 import { injectSkillContent } from "./skill-prompt-injector.js";
 import type { ReviewScope, LensStat } from "./output/summary-renderer.js";
+import type { ReviewState } from "./state/review-state.js";
+import type { OutputConfig } from "./config.js";
 
 // ============================================================
 // AI PR Review Orchestrator
@@ -98,6 +106,7 @@ export async function main(options?: RunOptions) {
   // 3. Fetch diff + apply exclude_patterns filter
   console.log("Fetching diff...");
   const rawDiff = fetchDiff(opts);
+  const totalDiffFiles = parseDiffFiles(rawDiff).length;
   const diff = filterDiffByExcludePatterns(rawDiff, config.filters.exclude_patterns);
   console.log(`  Diff size: ${rawDiff.length} -> ${diff.length} chars (after exclude filter)\n`);
 
@@ -148,6 +157,17 @@ export async function main(options?: RunOptions) {
       config.global.max_rounds
     );
   }
+  // 4a. Detect resolved inline comment threads (GitHub mode only)
+  const inlineCommentMap = buildInlineCommentMap(state.findings);
+  if (
+    opts.mode === "github" &&
+    process.env.GITHUB_TOKEN &&
+    config.output.github.inlineComments &&
+    Object.keys(inlineCommentMap).length > 0
+  ) {
+    state = await reconcileResolvedThreads(state, opts.prNumber, inlineCommentMap);
+  }
+
   console.log(`Round: ${state.current_round}/${state.max_rounds}`);
   console.log(
     `  Previous findings: ${state.findings.length} (open: ${state.findings.filter((f) => f.status === "open").length})\n`
@@ -322,27 +342,109 @@ export async function main(options?: RunOptions) {
   const scope: ReviewScope = {
     diffStats: parseDiffStats(diff),
     diffFiles,
+    totalDiffFiles,
     changeSummary,
     lensStats,
   };
 
   // 16. Output: GitHub API for github mode with token, stdout otherwise
+  const outputState = (
+    opts.mode === "github" &&
+    process.env.GITHUB_TOKEN &&
+    config.output.github.inlineComments
+  )
+    ? await postInlineAndMergeState(opts.prNumber, finalState, headSha, diffFiles, config.output)
+    : finalState;
+
   if (opts.mode === "github" && process.env.GITHUB_TOKEN) {
-    await upsertSummaryComment(opts.prNumber, finalState, decision, scope, config.output);
+    await upsertSummaryComment(opts.prNumber, outputState, decision, scope, config.output);
   } else {
     const { renderSummary } = await import(
       "./output/summary-renderer.js"
     );
+    const summary = renderSummary(outputState, decision, opts.mode, scope);
     console.log("\n--- Summary ---");
-    console.log(renderSummary(finalState, decision, opts.mode, scope));
+    console.log(summary);
+
+    if (opts.outputFile) {
+      try {
+        await writeFile(opts.outputFile, summary, "utf-8");
+        console.log(`\n  Summary written to ${opts.outputFile}`);
+      } catch (e) {
+        console.warn(`  Could not write summary to ${opts.outputFile}: ${e}`);
+      }
+    }
   }
 
   // 17. Save state (local mode only; GitHub mode persists via comment)
   if (opts.mode === "local") {
-    await saveState(opts.stateDir, finalState);
+    await saveState(opts.stateDir, outputState);
   }
 
   console.log("\nAI Review — Done.");
+}
+
+// ============================================================
+// Helpers extracted from orchestrator for readability
+// ============================================================
+
+/** Reconcile resolved GitHub review threads with finding state */
+async function reconcileResolvedThreads(
+  state: ReviewState,
+  prNumber: number,
+  commentMap: Record<string, number>
+): Promise<ReviewState> {
+  const resolvedIds = await fetchResolvedThreads(prNumber);
+  if (resolvedIds.size === 0) return state;
+
+  let resolvedCount = 0;
+  const updatedFindings = state.findings.map((f) => {
+    if (f.status !== "open") return f;
+    const commentId = commentMap[f.id];
+    if (commentId && resolvedIds.has(commentId)) {
+      resolvedCount++;
+      return {
+        ...f,
+        status: "addressed" as const,
+        resolution_note: "Resolved by reviewer",
+      };
+    }
+    return f;
+  });
+
+  if (resolvedCount === 0) return state;
+
+  console.log(`  Resolved threads detected: ${resolvedCount} finding(s) marked as addressed`);
+  return {
+    ...state,
+    findings: updatedFindings,
+    decisions: [...state.decisions, `${resolvedCount} finding(s) resolved by reviewer`],
+  };
+}
+
+/** Post inline review comments and merge comment IDs back into state */
+async function postInlineAndMergeState(
+  prNumber: number,
+  state: ReviewState,
+  headSha: string,
+  diffFiles: string[],
+  outputConfig: OutputConfig
+): Promise<ReviewState> {
+  const modifiedFiles = new Set(diffFiles);
+  const inlineResult = await submitInlineReview(
+    prNumber, state, headSha, modifiedFiles, outputConfig
+  );
+
+  if (Object.keys(inlineResult.postedComments).length === 0) return state;
+
+  return {
+    ...state,
+    last_inline_review_sha: headSha,
+    findings: state.findings.map((f) => {
+      const commentId = inlineResult.postedComments[f.id];
+      return commentId ? { ...f, inline_comment_id: commentId } : f;
+    }),
+  };
 }
 
 // In ESM, use import.meta.url to determine if this is the entry point.

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,6 +20,8 @@ export interface RunOptions {
   diffTarget: DiffTarget;
   cliBase: string | undefined;
   cliHead: string | undefined;
+  /** File path to write Markdown summary (local mode, optional) */
+  outputFile: string | undefined;
 }
 
 // Reject shell metacharacters to prevent command injection
@@ -40,6 +42,7 @@ export function resolveOptions(): RunOptions {
 
   const cliBase = parseArg(args, "--base");
   const cliHead = parseArg(args, "--head");
+  const outputFile = parseArg(args, "--output");
 
   if (cliBase !== undefined && !validateGitRef(cliBase)) {
     console.error(`Invalid git ref for --base: "${cliBase}"`);
@@ -71,6 +74,7 @@ export function resolveOptions(): RunOptions {
       diffTarget,
       cliBase,
       cliHead,
+      outputFile,
     };
   }
 
@@ -87,6 +91,7 @@ export function resolveOptions(): RunOptions {
     diffTarget,
     cliBase,
     cliHead,
+    outputFile,
   };
 }
 

--- a/src/output/inline-comments.ts
+++ b/src/output/inline-comments.ts
@@ -135,12 +135,17 @@ const SEVERITY_EMOJI: Record<string, string> = {
  * - File NOT modified + finding already has inline comment → skip (still valid)
  * - New finding → post
  */
+export interface InlineSelection {
+  findings: StateFinding[];
+  overflow: number;
+}
+
 export function selectFindingsForInline(
   state: ReviewState,
   modifiedFiles: Set<string>,
   config: GitHubOutputConfig,
   diff?: string
-): StateFinding[] {
+): InlineSelection {
   const allowedSeverities = new Set<string>(config.inlineSeverities);
   const diffRanges = diff ? parseDiffLineRanges(diff) : null;
 
@@ -173,8 +178,12 @@ export function selectFindingsForInline(
     return a.line_start - b.line_start;
   });
 
-  // Apply max limit
-  return sorted.slice(0, config.maxInlineComments);
+  // Apply max limit; overflow is computed from the same filtered set
+  const selected = sorted.slice(0, config.maxInlineComments);
+  return {
+    findings: selected,
+    overflow: Math.max(0, filtered.length - selected.length),
+  };
 }
 
 /** Build the ReviewComment array for octokit.pulls.createReview */
@@ -236,17 +245,3 @@ export function formatInlineBody(f: StateFinding): string {
   return lines.join("\n").trimEnd();
 }
 
-/**
- * Count how many findings were filtered out by the max limit.
- */
-export function countOverflow(
-  state: ReviewState,
-  posted: StateFinding[],
-  config: GitHubOutputConfig
-): number {
-  const allowedSeverities = new Set<string>(config.inlineSeverities);
-  const total = state.findings.filter(
-    (f) => f.status === "open" && allowedSeverities.has(f.severity)
-  ).length;
-  return Math.max(0, total - posted.length);
-}

--- a/src/output/inline-comments.ts
+++ b/src/output/inline-comments.ts
@@ -7,13 +7,55 @@ import { SEVERITY_RANK, type Severity } from "../severity.js";
 // from StateFinding[] for posting via pulls.createReview
 // ============================================================
 
-/** Regex matching the **[id]** pattern in inline comment bodies (e.g., **[b-001]**) */
+/** Marker prefix for machine-readable metadata in inline comments */
+const FINDING_MARKER_PREFIX = "<!-- diffelens-finding: ";
+const FINDING_MARKER_SUFFIX = " -->";
+
+/** Regex to extract the JSON metadata from an inline comment body */
+const FINDING_MARKER_PATTERN = /<!-- diffelens-finding: ({.*?}) -->/;
+
+/** Legacy regex for **[id]** pattern (fallback for pre-metadata comments) */
 export const FINDING_ID_PATTERN = /\*\*\[([a-z]-\d{3})\]\*\*/;
 
-/** Extract a finding ID from a comment body containing the **[id]** pattern */
+export interface FindingMetadata {
+  id: string;
+  lens: string;
+  round: number;
+  severity: string;
+  category: string;
+}
+
+/** Extract finding metadata from an inline comment body */
+export function extractFindingMetadata(body: string): FindingMetadata | null {
+  const match = body.match(FINDING_MARKER_PATTERN);
+  if (match) {
+    try {
+      return JSON.parse(match[1]) as FindingMetadata;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Extract a finding ID from a comment body (metadata marker → legacy **[id]** fallback) */
 export function extractFindingIdFromBody(body: string): string | null {
-  const match = body.match(FINDING_ID_PATTERN);
-  return match ? match[1] : null;
+  const meta = extractFindingMetadata(body);
+  if (meta) return meta.id;
+  const legacyMatch = body.match(FINDING_ID_PATTERN);
+  return legacyMatch ? legacyMatch[1] : null;
+}
+
+/** Build the HTML comment marker for a finding */
+function buildFindingMarker(f: StateFinding): string {
+  const meta: FindingMetadata = {
+    id: f.id,
+    lens: f.lens,
+    round: f.first_raised_round,
+    severity: f.severity,
+    category: f.category,
+  };
+  return `${FINDING_MARKER_PREFIX}${JSON.stringify(meta)}${FINDING_MARKER_SUFFIX}`;
 }
 
 /** Shape expected by octokit.pulls.createReview({ comments }) */
@@ -98,6 +140,9 @@ export function formatInlineBody(f: StateFinding): string {
   const emoji = SEVERITY_EMOJI[f.severity] ?? "";
   const lines: string[] = [];
 
+  // Machine-readable metadata (invisible to humans)
+  lines.push(buildFindingMarker(f));
+
   // Header: [id] severity | category
   lines.push(`**[${f.id}]** ${emoji} ${f.severity} | \`${f.category}\``);
   lines.push("");
@@ -127,7 +172,11 @@ export function formatInlineBody(f: StateFinding): string {
     lines.push(f.evidence);
     lines.push("");
     lines.push("</details>");
+    lines.push("");
   }
+
+  // Action hints for AI/bot consumers (invisible to humans)
+  lines.push(`<!-- diffelens-actions: dismiss=reply "/dismiss {reason}", resolve=click "Resolve conversation" -->`);
 
   return lines.join("\n").trimEnd();
 }

--- a/src/output/inline-comments.ts
+++ b/src/output/inline-comments.ts
@@ -73,6 +73,54 @@ export interface InlineReviewResult {
   overflow: number;
 }
 
+/** Line range in the new (right) side of a diff hunk */
+interface DiffLineRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Parse a unified diff to extract valid line ranges per file (new/right side).
+ * Returns a map of file path → array of valid line ranges.
+ */
+export function parseDiffLineRanges(diff: string): Map<string, DiffLineRange[]> {
+  const result = new Map<string, DiffLineRange[]>();
+  let currentFile: string | null = null;
+
+  for (const line of diff.split("\n")) {
+    const fileMatch = line.match(/^diff --git a\/(.+?) b\/(.+)/);
+    if (fileMatch) {
+      currentFile = fileMatch[2];
+      if (!result.has(currentFile)) {
+        result.set(currentFile, []);
+      }
+      continue;
+    }
+
+    // @@ -oldStart,oldCount +newStart,newCount @@
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (hunkMatch && currentFile) {
+      const start = parseInt(hunkMatch[1], 10);
+      const count = parseInt(hunkMatch[2] ?? "1", 10);
+      result.get(currentFile)!.push({ start, end: start + count - 1 });
+    }
+  }
+
+  return result;
+}
+
+/** Check if a finding's line range falls within any diff hunk for that file */
+function isLineInDiff(
+  file: string,
+  lineStart: number,
+  lineEnd: number,
+  diffRanges: Map<string, DiffLineRange[]>
+): boolean {
+  const ranges = diffRanges.get(file);
+  if (!ranges) return false;
+  return ranges.some((r) => lineEnd >= r.start && lineStart <= r.end);
+}
+
 const SEVERITY_EMOJI: Record<string, string> = {
   blocker: "🔴",
   warning: "🟡",
@@ -90,15 +138,22 @@ const SEVERITY_EMOJI: Record<string, string> = {
 export function selectFindingsForInline(
   state: ReviewState,
   modifiedFiles: Set<string>,
-  config: GitHubOutputConfig
+  config: GitHubOutputConfig,
+  diff?: string
 ): StateFinding[] {
   const allowedSeverities = new Set<string>(config.inlineSeverities);
+  const diffRanges = diff ? parseDiffLineRanges(diff) : null;
 
   const candidates = state.findings.filter(
     (f) => f.status === "open" && allowedSeverities.has(f.severity)
   );
 
   const filtered = candidates.filter((f) => {
+    // Skip findings whose lines are outside the diff (would cause "Line could not be resolved")
+    if (diffRanges && !isLineInDiff(f.file, f.line_start, f.line_end, diffRanges)) {
+      return false;
+    }
+
     // New finding (no inline comment yet) → always post
     if (!f.inline_comment_id) return true;
 

--- a/src/output/inline-comments.ts
+++ b/src/output/inline-comments.ts
@@ -1,0 +1,148 @@
+import type { StateFinding, ReviewState } from "../state/review-state.js";
+import type { GitHubOutputConfig } from "../config.js";
+import { SEVERITY_RANK, type Severity } from "../severity.js";
+
+// ============================================================
+// Inline Review Comments: build GitHub-native review comments
+// from StateFinding[] for posting via pulls.createReview
+// ============================================================
+
+/** Regex matching the **[id]** pattern in inline comment bodies (e.g., **[b-001]**) */
+export const FINDING_ID_PATTERN = /\*\*\[([a-z]-\d{3})\]\*\*/;
+
+/** Extract a finding ID from a comment body containing the **[id]** pattern */
+export function extractFindingIdFromBody(body: string): string | null {
+  const match = body.match(FINDING_ID_PATTERN);
+  return match ? match[1] : null;
+}
+
+/** Shape expected by octokit.pulls.createReview({ comments }) */
+export interface ReviewComment {
+  path: string;
+  line: number;
+  start_line?: number;
+  side: "RIGHT";
+  body: string;
+}
+
+/** Result of inline review posting, maps findingId → GitHub comment ID */
+export interface InlineReviewResult {
+  postedComments: Record<string, number>;
+  overflow: number;
+}
+
+const SEVERITY_EMOJI: Record<string, string> = {
+  blocker: "🔴",
+  warning: "🟡",
+  nitpick: "💬",
+};
+
+/**
+ * Determine which findings should be posted as inline comments.
+ *
+ * Noise-minimized multi-round logic:
+ * - File modified since last inline review → re-post (old comment is outdated)
+ * - File NOT modified + finding already has inline comment → skip (still valid)
+ * - New finding → post
+ */
+export function selectFindingsForInline(
+  state: ReviewState,
+  modifiedFiles: Set<string>,
+  config: GitHubOutputConfig
+): StateFinding[] {
+  const allowedSeverities = new Set<string>(config.inlineSeverities);
+
+  const candidates = state.findings.filter(
+    (f) => f.status === "open" && allowedSeverities.has(f.severity)
+  );
+
+  const filtered = candidates.filter((f) => {
+    // New finding (no inline comment yet) → always post
+    if (!f.inline_comment_id) return true;
+
+    // Existing inline comment, but file was modified → re-post on new code
+    if (modifiedFiles.has(f.file)) return true;
+
+    // Existing inline comment, file unchanged → skip (comment still valid)
+    return false;
+  });
+
+  // Sort by severity (blockers first) then by file/line
+  const sorted = [...filtered].sort((a, b) => {
+    const sevDiff = (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0);
+    if (sevDiff !== 0) return sevDiff;
+    const fileDiff = a.file.localeCompare(b.file);
+    if (fileDiff !== 0) return fileDiff;
+    return a.line_start - b.line_start;
+  });
+
+  // Apply max limit
+  return sorted.slice(0, config.maxInlineComments);
+}
+
+/** Build the ReviewComment array for octokit.pulls.createReview */
+export function buildReviewComments(
+  findings: StateFinding[]
+): ReviewComment[] {
+  return findings.map((f) => ({
+    path: f.file,
+    line: f.line_end,
+    ...(f.line_start < f.line_end ? { start_line: f.line_start } : {}),
+    side: "RIGHT" as const,
+    body: formatInlineBody(f),
+  }));
+}
+
+/** Format the Markdown body for a single inline comment */
+export function formatInlineBody(f: StateFinding): string {
+  const emoji = SEVERITY_EMOJI[f.severity] ?? "";
+  const lines: string[] = [];
+
+  // Header: [id] severity | category
+  lines.push(`**[${f.id}]** ${emoji} ${f.severity} | \`${f.category}\``);
+  lines.push("");
+
+  // Summary
+  lines.push(f.summary);
+  lines.push("");
+
+  // Suggestion text
+  if (f.suggestion) {
+    lines.push(`> 💡 ${f.suggestion}`);
+    lines.push("");
+  }
+
+  // GitHub suggestion block (exact code replacement)
+  if (f.suggestion_diff) {
+    lines.push("```suggestion");
+    lines.push(f.suggestion_diff);
+    lines.push("```");
+    lines.push("");
+  }
+
+  // Evidence (collapsible)
+  if (f.evidence) {
+    lines.push("<details><summary>Evidence</summary>");
+    lines.push("");
+    lines.push(f.evidence);
+    lines.push("");
+    lines.push("</details>");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+/**
+ * Count how many findings were filtered out by the max limit.
+ */
+export function countOverflow(
+  state: ReviewState,
+  posted: StateFinding[],
+  config: GitHubOutputConfig
+): number {
+  const allowedSeverities = new Set<string>(config.inlineSeverities);
+  const total = state.findings.filter(
+    (f) => f.status === "open" && allowedSeverities.has(f.severity)
+  ).length;
+  return Math.max(0, total - posted.length);
+}

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -45,7 +45,7 @@ export async function submitInlineReview(
   }
 
   try {
-    await octokit.pulls.createReview({
+    const { data: review } = await octokit.pulls.createReview({
       owner,
       repo,
       pull_number: prNumber,
@@ -55,25 +55,21 @@ export async function submitInlineReview(
       comments,
     });
 
-    // Map finding IDs back to posted comment IDs.
-    // GitHub's createReview doesn't return individual comment IDs, so we
-    // fetch recent review comments and reverse-match via the **[id]** pattern
-    // embedded in each comment body. Sorted DESC so the newest (just-posted)
-    // comment wins if duplicates exist for the same finding ID.
+    // Fetch only the comments belonging to the review we just posted,
+    // avoiding pagination issues with per_page: 100 on the full PR.
     const postedComments: Record<string, number> = {};
 
-    const { data: reviewComments } = await octokit.pulls.listReviewComments({
+    const { data: reviewComments } = await octokit.pulls.listCommentsForReview({
       owner,
       repo,
       pull_number: prNumber,
-      per_page: 100, // GitHub API max per page
-      sort: "created",
-      direction: "desc",
+      review_id: review.id,
+      per_page: 100,
     });
 
     for (const comment of reviewComments) {
       const findingId = extractFindingIdFromBody(comment.body ?? "");
-      if (findingId && selected.some((f) => f.id === findingId) && !(findingId in postedComments)) {
+      if (findingId) {
         postedComments[findingId] = comment.id;
       }
     }

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -2,7 +2,7 @@ import type { ReviewState } from "../state/review-state.js";
 import type { OutputConfig } from "../config.js";
 import { getOctokit, parseRepo } from "./github-client.js";
 import {
-  FINDING_ID_PATTERN,
+  extractFindingIdFromBody,
   selectFindingsForInline,
   buildReviewComments,
   countOverflow,
@@ -72,13 +72,9 @@ export async function submitInlineReview(
     });
 
     for (const comment of reviewComments) {
-      const match = comment.body?.match(FINDING_ID_PATTERN);
-      if (match) {
-        const findingId = match[1];
-        // Keep first match (newest) — skip if already mapped
-        if (selected.some((f) => f.id === findingId) && !(findingId in postedComments)) {
-          postedComments[findingId] = comment.id;
-        }
+      const findingId = extractFindingIdFromBody(comment.body ?? "");
+      if (findingId && selected.some((f) => f.id === findingId) && !(findingId in postedComments)) {
+        postedComments[findingId] = comment.id;
       }
     }
 

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -38,10 +38,7 @@ export async function submitInlineReview(
   const octokit = getOctokit();
   const { owner, repo } = parseRepo();
 
-  let reviewBody = `🤖 AI Review — ${selected.length} inline comment(s)`;
-  if (overflow > 0) {
-    reviewBody += ` (${overflow} more in summary)`;
-  }
+  const reviewBody = `🤖 AI Review — ${selected.length} inline comment(s)${overflow > 0 ? ` (${overflow} more in summary)` : ""}`;
 
   try {
     const { data: review } = await octokit.pulls.createReview({

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -5,7 +5,6 @@ import {
   extractFindingIdFromBody,
   selectFindingsForInline,
   buildReviewComments,
-  countOverflow,
   type InlineReviewResult,
 } from "./inline-comments.js";
 
@@ -28,14 +27,13 @@ export async function submitInlineReview(
   diff?: string
 ): Promise<InlineReviewResult> {
   const githubConfig = outputConfig.github;
-  const selected = selectFindingsForInline(state, modifiedFiles, githubConfig, diff);
+  const { findings: selected, overflow } = selectFindingsForInline(state, modifiedFiles, githubConfig, diff);
 
   if (selected.length === 0) {
     return { postedComments: {}, overflow: 0 };
   }
 
   const comments = buildReviewComments(selected);
-  const overflow = countOverflow(state, selected, githubConfig);
 
   const octokit = getOctokit();
   const { owner, repo } = parseRepo();

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -1,0 +1,158 @@
+import type { ReviewState } from "../state/review-state.js";
+import type { OutputConfig } from "../config.js";
+import { getOctokit, parseRepo } from "./github-client.js";
+import {
+  FINDING_ID_PATTERN,
+  selectFindingsForInline,
+  buildReviewComments,
+  countOverflow,
+  type InlineReviewResult,
+} from "./inline-comments.js";
+
+// ============================================================
+// Inline Review Client: GitHub API calls for inline comments
+// and resolved thread detection
+// ============================================================
+
+/**
+ * Submit inline review comments for findings.
+ * Posts all comments as a single COMMENT-event review (one notification).
+ * Returns a map of findingId → GitHub review comment ID.
+ */
+export async function submitInlineReview(
+  prNumber: number,
+  state: ReviewState,
+  commitSha: string,
+  modifiedFiles: Set<string>,
+  outputConfig: OutputConfig
+): Promise<InlineReviewResult> {
+  const githubConfig = outputConfig.github;
+  const selected = selectFindingsForInline(state, modifiedFiles, githubConfig);
+
+  if (selected.length === 0) {
+    return { postedComments: {}, overflow: 0 };
+  }
+
+  const comments = buildReviewComments(selected);
+  const overflow = countOverflow(state, selected, githubConfig);
+
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo();
+
+  let reviewBody = `🤖 AI Review — ${selected.length} inline comment(s)`;
+  if (overflow > 0) {
+    reviewBody += ` (${overflow} more in summary)`;
+  }
+
+  try {
+    await octokit.pulls.createReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      commit_id: commitSha,
+      event: "COMMENT",
+      body: reviewBody,
+      comments,
+    });
+
+    // Map finding IDs back to posted comment IDs.
+    // GitHub's createReview doesn't return individual comment IDs, so we
+    // fetch recent review comments and reverse-match via the **[id]** pattern
+    // embedded in each comment body. Sorted DESC so the newest (just-posted)
+    // comment wins if duplicates exist for the same finding ID.
+    const postedComments: Record<string, number> = {};
+
+    const { data: reviewComments } = await octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 100, // GitHub API max per page
+      sort: "created",
+      direction: "desc",
+    });
+
+    for (const comment of reviewComments) {
+      const match = comment.body?.match(FINDING_ID_PATTERN);
+      if (match) {
+        const findingId = match[1];
+        // Keep first match (newest) — skip if already mapped
+        if (selected.some((f) => f.id === findingId) && !(findingId in postedComments)) {
+          postedComments[findingId] = comment.id;
+        }
+      }
+    }
+
+    console.log(
+      `  Inline review posted: ${selected.length} comments` +
+      (overflow > 0 ? ` (${overflow} overflow)` : "")
+    );
+
+    return { postedComments, overflow };
+  } catch (e) {
+    console.warn(`  Could not submit inline review: ${e}`);
+    return { postedComments: {}, overflow: 0 };
+  }
+}
+
+interface ResolvedThreadsResponse {
+  repository: {
+    pullRequest: {
+      reviewThreads: {
+        nodes: Array<{
+          isResolved: boolean;
+          comments: { nodes: Array<{ databaseId: number }> };
+        }>;
+      };
+    };
+  };
+}
+
+/**
+ * Fetch IDs of resolved review threads via GraphQL.
+ * Returns a Set of review comment database IDs that belong to resolved threads.
+ */
+export async function fetchResolvedThreads(
+  prNumber: number
+): Promise<Set<number>> {
+  const octokit = getOctokit();
+  const { owner, repo } = parseRepo();
+
+  try {
+    const result: ResolvedThreadsResponse = await octokit.graphql(
+      `query($owner: String!, $repo: String!, $pr: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $pr) {
+            reviewThreads(first: 100) {
+              nodes {
+                isResolved
+                comments(first: 1) {
+                  nodes { databaseId }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { owner, repo, pr: prNumber }
+    );
+
+    const threads = result.repository.pullRequest.reviewThreads.nodes;
+    if (threads.length >= 100) {
+      console.warn("  Warning: 100+ review threads — some resolved threads may not be detected");
+    }
+
+    const resolvedIds = new Set<number>();
+    for (const thread of threads) {
+      if (thread.isResolved) {
+        for (const comment of thread.comments.nodes) {
+          resolvedIds.add(comment.databaseId);
+        }
+      }
+    }
+
+    return resolvedIds;
+  } catch (e) {
+    console.warn(`  Could not fetch resolved threads: ${e}`);
+    return new Set();
+  }
+}

--- a/src/output/inline-review-client.ts
+++ b/src/output/inline-review-client.ts
@@ -24,10 +24,11 @@ export async function submitInlineReview(
   state: ReviewState,
   commitSha: string,
   modifiedFiles: Set<string>,
-  outputConfig: OutputConfig
+  outputConfig: OutputConfig,
+  diff?: string
 ): Promise<InlineReviewResult> {
   const githubConfig = outputConfig.github;
-  const selected = selectFindingsForInline(state, modifiedFiles, githubConfig);
+  const selected = selectFindingsForInline(state, modifiedFiles, githubConfig, diff);
 
   if (selected.length === 0) {
     return { postedComments: {}, overflow: 0 };

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -22,6 +22,8 @@ export interface LensStat {
 export interface ReviewScope {
   diffStats: DiffStats;
   diffFiles: string[];
+  /** Total files before exclude_patterns filter (for coverage display) */
+  totalDiffFiles?: number;
   changeSummary: string | null;
   lensStats: LensStat[];
 }
@@ -74,11 +76,21 @@ export function renderSummary(
     lines.push(...renderScope(scope));
   }
 
+  // Round history (collapsible, show if more than 1 round)
+  if (state.round_history.length > 0) {
+    lines.push(...renderRoundHistory(state));
+  }
+
+  // Human action log
+  if (state.decisions.length > 0) {
+    lines.push(...renderDecisions(state.decisions));
+  }
+
   // Blockers
   if (blockers.length > 0) {
     lines.push("---", "", "### 🔴 Blockers", "");
     for (const f of blockers) {
-      lines.push(...renderFinding(f, state.current_round));
+      lines.push(...renderFinding(f, state.current_round, mode));
     }
   }
 
@@ -92,7 +104,7 @@ export function renderSummary(
       ""
     );
     for (const f of warnings) {
-      lines.push(...renderFinding(f, state.current_round));
+      lines.push(...renderFinding(f, state.current_round, mode));
     }
     lines.push("</details>", "");
   }
@@ -107,7 +119,7 @@ export function renderSummary(
       ""
     );
     for (const f of nitpicks) {
-      lines.push(...renderFinding(f, state.current_round));
+      lines.push(...renderFinding(f, state.current_round, mode));
     }
     lines.push("</details>", "");
   }
@@ -136,6 +148,8 @@ export function renderSummary(
     lines.push(
       "---",
       "<sub>",
+      `💬 Dismiss: <code>npx tsx src/handle-command.ts dismiss {id} {reason}</code>`,
+      "<br>",
       `🔄 Re-run to check convergence after fixing issues`,
       "</sub>"
     );
@@ -178,6 +192,15 @@ function renderScope(scope: ReviewScope): string[] {
     `<details><summary>📋 ${summaryText}</summary>`,
     "",
   ];
+
+  // Coverage note (how many files were excluded by filters)
+  if (scope.totalDiffFiles != null && scope.totalDiffFiles > diffFiles.length) {
+    const excluded = scope.totalDiffFiles - diffFiles.length;
+    lines.push(
+      `> **Coverage**: ${diffFiles.length}/${scope.totalDiffFiles} changed files reviewed (${excluded} excluded by filters)`,
+      "",
+    );
+  }
 
   // Change summary (from LLM, best effort)
   if (changeSummary) {
@@ -251,7 +274,11 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-function renderFinding(f: StateFinding, currentRound: number): string[] {
+function renderFinding(
+  f: StateFinding,
+  currentRound: number,
+  mode: "github" | "local" = "github"
+): string[] {
   const lines: string[] = [];
   const lineRef =
     f.line_start === f.line_end
@@ -266,6 +293,11 @@ function renderFinding(f: StateFinding, currentRound: number): string[] {
     lines.push(`  > 💡 ${f.suggestion}`);
   }
 
+  // Evidence: shown inline in local mode (no inline comments available)
+  if (mode === "local" && f.evidence) {
+    lines.push(`  > 🔎 ${f.evidence}`);
+  }
+
   const lensLabel = f.lens ?? "unknown";
   const roundLabel =
     f.first_raised_round < currentRound
@@ -275,6 +307,45 @@ function renderFinding(f: StateFinding, currentRound: number): string[] {
   lines.push(`  > 🔍 Lens: \`${lensLabel}\` / ${roundLabel}`);
   lines.push("");
 
+  return lines;
+}
+
+function renderRoundHistory(state: ReviewState): string[] {
+  const lines: string[] = [
+    `<details><summary>📊 Round History (${state.round_history.length})</summary>`,
+    "",
+    "| Round | SHA | Opened | Resolved |",
+    "|-------|-----|--------|----------|",
+  ];
+
+  for (const rh of state.round_history) {
+    const sha = rh.head_sha.slice(0, 7);
+    const opened = rh.findings_opened.length > 0
+      ? rh.findings_opened.join(", ")
+      : "—";
+    const resolved = rh.findings_resolved.length > 0
+      ? rh.findings_resolved.join(", ")
+      : "—";
+    lines.push(`| ${rh.round} | ${sha} | ${opened} | ${resolved} |`);
+  }
+
+  lines.push("", "</details>", "");
+  return lines;
+}
+
+function renderDecisions(decisions: string[]): string[] {
+  if (decisions.length === 0) return [];
+
+  const lines: string[] = [
+    `<details><summary>👤 Human Actions (${decisions.length})</summary>`,
+    "",
+  ];
+
+  for (const d of decisions) {
+    lines.push(`- ${d}`);
+  }
+
+  lines.push("", "</details>", "");
   return lines;
 }
 

--- a/src/output/summary-renderer.ts
+++ b/src/output/summary-renderer.ts
@@ -49,8 +49,19 @@ export function renderSummary(
 
   const suppressionCount = state.recurrence_suppressions?.length ?? 0;
 
+  const meta = {
+    decision,
+    round: state.current_round,
+    max_rounds: state.max_rounds,
+    blockers: blockers.length,
+    warnings: warnings.length,
+    nitpicks: nitpicks.length,
+    resolved: resolved.length,
+  };
+
   const lines: string[] = [
     MARKER,
+    `<!-- diffelens-meta: ${JSON.stringify(meta)} -->`,
     `## 🤖 AI Review — Round ${state.current_round}/${state.max_rounds}`,
     "",
     `**${decisionEmoji}**`,

--- a/src/state/review-state.ts
+++ b/src/state/review-state.ts
@@ -14,6 +14,8 @@ export interface StateFinding extends Finding {
   first_raised_round: number;
   last_evaluated_round: number;
   resolution_note: string | null;
+  /** GitHub review comment ID (if posted as inline comment) */
+  inline_comment_id?: number;
 }
 
 export interface RoundHistory {
@@ -47,6 +49,8 @@ export interface ReviewState {
   round_history: RoundHistory[];
   decisions: string[];
   recurrence_suppressions?: RecurrenceSuppression[];
+  /** Commit SHA when inline comments were last posted */
+  last_inline_review_sha?: string;
 }
 
 function stateFilePath(stateDir: string, stateKey: string): string {
@@ -103,7 +107,7 @@ export function createInitialState(
   maxRounds: number
 ): ReviewState {
   return {
-    schema_version: "1.0",
+    schema_version: "1.1",
     pr_number: prNumber,
     repository: process.env.GITHUB_REPOSITORY ?? "unknown",
     current_round: 1,
@@ -239,6 +243,19 @@ export function linesOverlap(
 export function generateFindingId(lens: string, index: number): string {
   const prefix = lens.charAt(0); // r, s, b
   return `${prefix}-${String(index + 1).padStart(3, "0")}`;
+}
+
+/** Derive findingId → inline comment ID map from findings (single source of truth) */
+export function buildInlineCommentMap(
+  findings: readonly StateFinding[]
+): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const f of findings) {
+    if (f.inline_comment_id != null) {
+      map[f.id] = f.inline_comment_id;
+    }
+  }
+  return map;
 }
 
 /** Merge recurrence suppression history into state (immutable, deduped by originalFindingId) */


### PR DESCRIPTION
## Summary

- **Inline review comments**: Post blocker/warning findings as GitHub-native review comments on exact code lines, with suggestion blocks and collapsible evidence
- **Enhanced dashboard**: Add exploration coverage, round history, per-lens breakdown, and human action log to the summary comment
- **Human-AI collaboration**: Detect resolved review threads via GraphQL, support `/dismiss` in thread replies, and local CLI dismiss

## Design

3-layer Progressive Disclosure architecture serving three user scenarios:

| Layer | What | Who |
|-------|------|-----|
| **Dashboard** (summary comment) | Counts, coverage, round history, finding links | Supervisors, reviewers |
| **Inline comments** (on code) | severity + summary + suggestion + evidence | Developers, reviewers |
| **Interaction** (thread actions) | Resolve = confirmed, /dismiss = rejected | All |

### Key design decisions
- Inline comments for blocker + warning only (nitpicks stay in summary to reduce noise)
- Noise-minimized multi-round: only re-post when the file changed (old comments auto-outdated by GitHub)
- Single `createReview` call per round (one notification, not N)
- `COMMENT` event for inline, separate `APPROVE`/`REQUEST_CHANGES` for approval
- `inline_comment_id` on `StateFinding` as single source of truth (no dual tracking)

### Local mode improvements
- Evidence shown directly in finding text (no collapsible `<details>` in terminal)
- `--output <path>` option for Markdown file export
- `npx tsx src/handle-command.ts dismiss <id> <reason>` for local dismiss

## Config

```yaml
output:
  github:
    inline_comments: true          # opt-in, default: false
    max_inline_comments: 25
    inline_severities: [blocker, warning]
```

## Files changed

| Area | Files | Description |
|------|-------|-------------|
| Types | `adapters/types.ts`, `state/review-state.ts` | `evidence`, `suggestion_diff`, `inline_comment_id`, schema 1.1 |
| Config | `config.ts`, `options.ts` | Inline comment settings, `--output` option |
| Inline comments | `output/inline-comments.ts` (new) | Comment building, formatting, selection logic |
| Inline API | `output/inline-review-client.ts` (new) | GitHub API for inline review + resolved thread detection |
| Dashboard | `output/summary-renderer.ts` | Coverage, round history, human actions, local evidence |
| Orchestrator | `main.ts` | Inline posting, resolve detection, file output |
| Dismiss | `handle-command.ts` | Refactored: shared `executeDismiss`, local CLI, thread reply |
| Prompts | `prompts/*.md` | `evidence` and `suggestion_diff` output fields |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 211/211 tests passing
- [x] diffelens self-review (4 rounds, all blockers/warnings/nitpicks resolved)
- [ ] Integration test: enable `inline_comments: true` on a test PR, verify inline comments appear
- [ ] Multi-round test: push new commit, verify smart re-post (changed files only)
- [ ] Resolve test: resolve a thread, re-run, verify finding marked as addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)