### PR TITLE
fix(adapter): improve CLI error logging for debugging API failures

### DIFF
--- a/src/lens-runner.ts
+++ b/src/lens-runner.ts
@@ -66,9 +66,10 @@ export async function runLens(
         `    [${config.name}] CLI failed (exit=${response.exitCode})`
       );
       if (response.rawStderr) {
-        console.error(
-          `    [${config.name}] stderr: ${response.rawStderr.slice(0, 300)}`
-        );
+        console.error(`    [${config.name}] stderr: ${response.rawStderr}`);
+      }
+      if (response.rawStdout) {
+        console.error(`    [${config.name}] stdout: ${response.rawStdout}`);
       }
       return {
         lens: config.name,
@@ -77,8 +78,7 @@ export async function runLens(
         output: null,
         durationMs: response.durationMs,
         success: false,
-        error:
-          response.rawStderr.slice(0, 500) || "Failed to parse output",
+        error: response.rawStderr || "Failed to parse output",
       };
     }
 


### PR DESCRIPTION
## Summary

- Remove stderr/stdout truncation (`slice(0, 300)`) in lens-runner error output
- Log full stderr and stdout on CLI failure for complete error visibility in CI
- Helps diagnose the Gemini API error seen in #17

## Context

Gemini CLI fails in GitHub Actions with `Error when talking to Gemini API` but the error details were truncated. This change ensures full error messages are visible in CI logs for diagnosis.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 211/211 tests passing
- [ ] Merge and re-run #17 to see full Gemini error output

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)