### PR TITLE
test: dismiss workflow verification

### DIFF
--- a/src/handle-command.ts
+++ b/src/handle-command.ts
@@ -58,7 +58,7 @@ function applyDismiss(
   };
 }
 
-/** Update the GitHub summary comment with new state via upsertSummaryComment */
+/** Update the GitHub summary comment with new state (no PR review action — dismiss only updates the comment) */
 async function updateGitHubSummary(
   updatedState: ReviewState,
   prNumber: number
@@ -66,7 +66,9 @@ async function updateGitHubSummary(
   const configPath = process.env.CONFIG_PATH ?? ".diffelens.yaml";
   const config = await loadConfig(configPath);
   const decision = checkConvergence(updatedState, config.convergence);
-  await upsertSummaryComment(prNumber, updatedState, decision, undefined, config.output);
+  // Pass no outputConfig to skip PR review submission (APPROVE/REQUEST_CHANGES).
+  // Dismiss operations should only update the summary comment, not re-submit reviews.
+  await upsertSummaryComment(prNumber, updatedState, decision);
 }
 
 type CommentType = "issue_comment" | "review_comment";

--- a/src/output/inline-comments.ts
+++ b/src/output/inline-comments.ts
@@ -245,3 +245,33 @@ export function formatInlineBody(f: StateFinding): string {
   return lines.join("\n").trimEnd();
 }
 
+// --- Test code for dismiss verification (intentional issues) ---
+
+/** Process user config — intentionally buggy for testing */
+export function processUserConfig(config: any) {
+  // Bug: no null check on nested access
+  const timeout = config.settings.timeout;
+  const name = config.user.profile.displayName.trim();
+
+  // Bug: no error handling on parse
+  const data = JSON.parse(config.rawData);
+
+  // Readability: deeply nested
+  if (data) {
+    if (data.items) {
+      for (const item of data.items) {
+        if (item.enabled) {
+          if (item.children) {
+            for (const child of item.children) {
+              if (child.type === "special") {
+                console.log(child.value);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { timeout, name, data };
+}


### PR DESCRIPTION
Test PR to verify inline comment dismiss workflow.

Intentionally buggy code added to trigger inline review comments.
Will test `/dismiss` reply in inline threads.

This PR will be closed after testing.