### PR TITLE
fix(command): skip PR review submission on dismiss operations

### DIFF
--- a/src/handle-command.ts
+++ b/src/handle-command.ts
@@ -58,7 +58,7 @@ function applyDismiss(
   };
 }
 
-/** Update the GitHub summary comment with new state via upsertSummaryComment */
+/** Update the GitHub summary comment with new state (no PR review action — dismiss only updates the comment) */
 async function updateGitHubSummary(
   updatedState: ReviewState,
   prNumber: number
@@ -66,7 +66,9 @@ async function updateGitHubSummary(
   const configPath = process.env.CONFIG_PATH ?? ".diffelens.yaml";
   const config = await loadConfig(configPath);
   const decision = checkConvergence(updatedState, config.convergence);
-  await upsertSummaryComment(prNumber, updatedState, decision, undefined, config.output);
+  // Pass no outputConfig to skip PR review submission (APPROVE/REQUEST_CHANGES).
+  // Dismiss operations should only update the summary comment, not re-submit reviews.
+  await upsertSummaryComment(prNumber, updatedState, decision);
 }
 
 type CommentType = "issue_comment" | "review_comment";


### PR DESCRIPTION
## Summary

- Dismiss operations no longer re-submit APPROVE/REQUEST_CHANGES PR reviews
- Only the summary comment is updated when a finding is dismissed

## Context

When a user dismissed a finding via `/dismiss` in an inline comment thread, `upsertSummaryComment` was called with the full output config, causing a duplicate REQUEST_CHANGES review to be submitted. This fix passes no output config so `resolveReviewAction` returns null.

Verified on test PR #20.

## Test plan

- [x] `/dismiss` in inline thread → summary updated, no duplicate review
- [x] TypeScript clean